### PR TITLE
Refactor Recommendation System

### DIFF
--- a/src/main/java/seedu/savenus/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/AddCommand.java
@@ -65,9 +65,8 @@ public class AddCommand extends Command {
         }
         model.addFood(toAdd);
 
-        // Reset the predicate and comparator, if any was provided
-        model.updateFilteredFoodList(Model.PREDICATE_SHOW_ALL_FOOD);
-        model.resetRecommendationComparator();
+        // Clear the recommendation system (if it was used)
+        model.setRecommendationSystemInUse(false);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/savenus/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/ListCommand.java
@@ -18,9 +18,9 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        // Reset the predicate and comparator, if any was provided
-        model.updateFilteredFoodList(Model.PREDICATE_SHOW_ALL_FOOD);
-        model.resetRecommendationComparator();
+        // Clear the recommendation system (if it was used) and show all food items
+        model.updateFilteredFoodList(x -> true);
+        model.setRecommendationSystemInUse(false);
 
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/savenus/logic/commands/RecommendCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/RecommendCommand.java
@@ -2,11 +2,7 @@ package seedu.savenus.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Comparator;
-import java.util.function.Predicate;
-
 import seedu.savenus.model.Model;
-import seedu.savenus.model.food.Food;
 
 /**
  * Recommends food to the user.
@@ -17,19 +13,11 @@ public class RecommendCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Here are your recommendations:";
 
-    // Placeholder, to be replaced with user's current budget
-    private static final Predicate<Food> BUDGET_RECOMMENDATION = f -> Double.parseDouble(f.getPrice().value) < 50;
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        /*
-         * Currently this only filters based on given budget and sorts them by price.
-         * The recommendations can be cleared using the list command.
-         */
-        model.updateFilteredFoodList(BUDGET_RECOMMENDATION);
-        model.updateRecommendationComparator(Comparator.comparingDouble(x -> Double.parseDouble(x.getPrice().value)));
+        model.setRecommendationSystemInUse(true);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/savenus/model/Model.java
+++ b/src/main/java/seedu/savenus/model/Model.java
@@ -115,13 +115,25 @@ public interface Model {
     void updateFilteredFoodList(Predicate<Food> predicate);
 
     /**
+     * Gets the current recommendation system.
+     */
+    RecommendationSystem getRecommendationSystem();
+
+    /**
      * Updates the comparator of the food list to filter by the given {@code comparator}.
      * @throws NullPointerException if {@code comparator} is null.
      */
     void updateRecommendationComparator(Comparator<Food> recommendationComparator);
 
     /**
-     * Resets the comparator of the food list..
+     * Updates the filter of the recommendation system's food list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
      */
-    void resetRecommendationComparator();
+    void updateRecommendationPredicate(Predicate<Food> recommendationPredicate);
+
+    /**
+     * Updates if the recommendation system is currently in use.
+     * @throws NullPointerException if {@code inUse} is null.
+     */
+    void setRecommendationSystemInUse(boolean inUse);
 }

--- a/src/main/java/seedu/savenus/model/RecommendationSystem.java
+++ b/src/main/java/seedu/savenus/model/RecommendationSystem.java
@@ -15,6 +15,9 @@ import seedu.savenus.model.tag.Tag;
  */
 public class RecommendationSystem {
 
+    private static final Comparator<Food> DEFAULT_COMPARATOR = (x, y) -> 0;
+    private static final Predicate<Food> DEFAULT_PREDICATE = x -> true;
+
     private Comparator<Food> recommendationComparator;
     private Predicate<Food> recommendationPredicate;
     private boolean inUse;
@@ -48,7 +51,7 @@ public class RecommendationSystem {
         if (inUse) {
             return recommendationComparator;
         } else {
-            return (x, y) -> 0;
+            return DEFAULT_COMPARATOR;
         }
     }
 
@@ -60,7 +63,7 @@ public class RecommendationSystem {
         if (inUse) {
             return recommendationPredicate;
         } else {
-            return x -> true;
+            return DEFAULT_PREDICATE;
         }
     }
 

--- a/src/main/java/seedu/savenus/model/RecommendationSystem.java
+++ b/src/main/java/seedu/savenus/model/RecommendationSystem.java
@@ -1,0 +1,78 @@
+package seedu.savenus.model;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.savenus.model.food.Category;
+import seedu.savenus.model.food.Food;
+import seedu.savenus.model.food.Location;
+import seedu.savenus.model.tag.Tag;
+
+/**
+ * Represents the Recommendation System of the menu.
+ */
+public class RecommendationSystem {
+
+    private Comparator<Food> recommendationComparator;
+    private Predicate<Food> recommendationPredicate;
+    private boolean inUse;
+
+    // TODO
+    private final Set<Tag> likedTags;
+    private final Set<Location> likedLocations;
+    private final Set<Category> likedCategories;
+
+    private final Set<Tag> dislikedTags;
+    private final Set<Location> dislikedLocations;
+    private final Set<Category> dislikedCategories;
+
+    public RecommendationSystem() {
+        this.inUse = false;
+
+        // TODO: Dummy comparators and predicates
+        recommendationComparator = Comparator.comparingDouble(x -> Double.parseDouble(x.getPrice().value));
+        recommendationPredicate = f -> Double.parseDouble(f.getPrice().value) < 50;
+
+        likedTags = new HashSet<>();
+        likedLocations = new HashSet<>();
+        likedCategories = new HashSet<>();
+
+        dislikedTags = new HashSet<>();
+        dislikedLocations = new HashSet<>();
+        dislikedCategories = new HashSet<>();
+    }
+
+    public Comparator<Food> getRecommendationComparator() {
+        if (inUse) {
+            return recommendationComparator;
+        } else {
+            return (x, y) -> 0;
+        }
+    }
+
+    public void setRecommendationComparator(Comparator<Food> recommendationComparator) {
+        this.recommendationComparator = recommendationComparator;
+    }
+
+    public Predicate<Food> getRecommendationPredicate() {
+        if (inUse) {
+            return recommendationPredicate;
+        } else {
+            return x -> true;
+        }
+    }
+
+    public void setRecommendationPredicate(Predicate<Food> recommendationPredicate) {
+        this.recommendationPredicate = recommendationPredicate;
+    }
+
+    public boolean isInUse() {
+        return inUse;
+    }
+
+    public void setInUse(boolean inUse) {
+        this.inUse = inUse;
+    }
+}

--- a/src/test/java/seedu/savenus/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/AddCommandTest.java
@@ -23,6 +23,7 @@ import seedu.savenus.model.Menu;
 import seedu.savenus.model.Model;
 import seedu.savenus.model.ReadOnlyMenu;
 import seedu.savenus.model.ReadOnlyUserPrefs;
+import seedu.savenus.model.RecommendationSystem;
 import seedu.savenus.model.food.Food;
 import seedu.savenus.model.wallet.DaysToExpire;
 import seedu.savenus.model.wallet.RemainingBudget;
@@ -175,6 +176,12 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredFoodList(Predicate<Food> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public RecommendationSystem getRecommendationSystem() {
+            throw new AssertionError("This method should not be called.");
         }
 
         @Override
@@ -183,7 +190,13 @@ public class AddCommandTest {
         }
 
         @Override
-        public void resetRecommendationComparator() {
+        public void updateRecommendationPredicate(Predicate<Food> recommendationPredicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setRecommendationSystemInUse(boolean inUse) {
+            // Empty stub
         }
     }
 

--- a/src/test/java/seedu/savenus/logic/commands/RecommendCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/RecommendCommandTest.java
@@ -1,0 +1,70 @@
+package seedu.savenus.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.savenus.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.savenus.testutil.TypicalMenu.CHICKEN_RICE;
+import static seedu.savenus.testutil.TypicalMenu.getTypicalMenu;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.savenus.logic.commands.exceptions.CommandException;
+import seedu.savenus.model.Model;
+import seedu.savenus.model.ModelManager;
+import seedu.savenus.model.UserPrefs;
+
+/**
+ * Contains integration tests and unit tests for RecommendCommand.
+ */
+public class RecommendCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalMenu(), new UserPrefs());
+        expectedModel = new ModelManager(model.getMenu(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_recommendCommand() {
+        assertCommandSuccess(new RecommendCommand(), model, RecommendCommand.MESSAGE_SUCCESS, expectedModel);
+        assertTrue(model.getRecommendationSystem().isInUse());
+    }
+
+    @Test
+    public void recommendCommand_notInUse_afterList() {
+        assertCommandSuccess(new RecommendCommand(), model, RecommendCommand.MESSAGE_SUCCESS, expectedModel);
+        assertTrue(model.getRecommendationSystem().isInUse());
+
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertFalse(model.getRecommendationSystem().isInUse());
+    }
+
+    @Test
+    public void recommendCommand_notInUse_afterAdd() throws CommandException {
+        assertCommandSuccess(new RecommendCommand(), model, RecommendCommand.MESSAGE_SUCCESS, expectedModel);
+        assertTrue(model.getRecommendationSystem().isInUse());
+
+        CommandResult commandResult = new AddCommand(CHICKEN_RICE).execute(model);
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, CHICKEN_RICE), commandResult.getFeedbackToUser());
+
+        assertFalse(model.getRecommendationSystem().isInUse());
+    }
+
+    @Test
+    public void equals() {
+        final RecommendCommand standardCommand = new RecommendCommand();
+
+        // same object -> returns true
+        assertEquals(standardCommand, standardCommand);
+
+        // null -> returns false
+        assertNotEquals(null, standardCommand);
+    }
+
+}

--- a/src/test/java/seedu/savenus/model/ModelManagerTest.java
+++ b/src/test/java/seedu/savenus/model/ModelManagerTest.java
@@ -2,6 +2,7 @@ package seedu.savenus.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.savenus.model.Model.PREDICATE_SHOW_ALL_FOOD;
 import static seedu.savenus.testutil.Assert.assertThrows;
@@ -11,10 +12,13 @@ import static seedu.savenus.testutil.TypicalMenu.TONKATSU_RAMEN;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.savenus.commons.core.GuiSettings;
+import seedu.savenus.model.food.Food;
 import seedu.savenus.model.food.NameContainsKeywordsPredicate;
 import seedu.savenus.testutil.MenuBuilder;
 
@@ -91,6 +95,52 @@ public class ModelManagerTest {
     @Test
     public void getFilteredfoodList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredFoodList().remove(0));
+    }
+
+    @Test
+    public void nullRecommendationComparator_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.updateRecommendationComparator(null));
+    }
+
+    @Test
+    public void nullRecommendationPredicate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.updateRecommendationPredicate(null));
+    }
+
+    @Test
+    public void updateRecommendationPredicate_inUse() {
+        Predicate<Food> recommendationPredicate = x -> false;
+        modelManager.updateRecommendationPredicate(recommendationPredicate);
+        modelManager.setRecommendationSystemInUse(true);
+
+        assertEquals(recommendationPredicate, modelManager.getRecommendationSystem().getRecommendationPredicate());
+    }
+
+    @Test
+    public void updateRecommendationPredicate_notInUse() {
+        Predicate<Food> recommendationPredicate = x -> false;
+        modelManager.updateRecommendationPredicate(recommendationPredicate);
+        modelManager.setRecommendationSystemInUse(false);
+
+        assertNotEquals(recommendationPredicate, modelManager.getRecommendationSystem().getRecommendationPredicate());
+    }
+
+    @Test
+    public void updateRecommendationComparator_inUse() {
+        Comparator<Food> recommendationComparator = (x, y) -> 12345;
+        modelManager.updateRecommendationComparator(recommendationComparator);
+        modelManager.setRecommendationSystemInUse(true);
+
+        assertEquals(recommendationComparator, modelManager.getRecommendationSystem().getRecommendationComparator());
+    }
+
+    @Test
+    public void updateRecommendationComparator_notInUse() {
+        Comparator<Food> recommendationComparator = (x, y) -> 12345;
+        modelManager.updateRecommendationComparator(recommendationComparator);
+        modelManager.setRecommendationSystemInUse(false);
+
+        assertNotEquals(recommendationComparator, modelManager.getRecommendationSystem().getRecommendationComparator());
     }
 
     @Test


### PR DESCRIPTION
Part of #38 

`ModelManager` now includes a `RecommendationSystem`.

The `recommend` command now sets `inUse` to `true` while `list` and `add` commands sets `inUse` to `false`. Further tests were also added.

Finally, some dummy values demoing the recommendation system were added.