### PR TITLE
Add purchase-related tests

### DIFF
--- a/src/main/java/seedu/savenus/model/Menu.java
+++ b/src/main/java/seedu/savenus/model/Menu.java
@@ -3,6 +3,7 @@ package seedu.savenus.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.savenus.model.food.Food;
@@ -144,10 +145,12 @@ public class Menu implements ReadOnlyMenu {
     }
 
     /**
-     * Buy food (Adds food to user's {@code PurchaseHistory}).
+     * Remove food (Remove food in user's {@code PurchaseHistory}).
      */
     public void removePurchase(Purchase purchase) {
-        //TODO
+        List<Purchase> currentPurchaseHistory = getPurchaseHistory().stream().collect(Collectors.toList());
+        currentPurchaseHistory.remove(purchase);
+        setPurchaseHistory(currentPurchaseHistory);
     }
 
 

--- a/src/main/java/seedu/savenus/model/ModelManager.java
+++ b/src/main/java/seedu/savenus/model/ModelManager.java
@@ -138,7 +138,7 @@ public class ModelManager implements Model {
 
     @Override
     public void removePurchase(Purchase target) {
-        //TODO
+        menu.removePurchase(target);
     }
 
     //=========== Filtered Purchase List Accessors =============================================================

--- a/src/main/java/seedu/savenus/model/purchase/Purchase.java
+++ b/src/main/java/seedu/savenus/model/purchase/Purchase.java
@@ -1,5 +1,6 @@
 package seedu.savenus.model.purchase;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Objects;
@@ -42,11 +43,23 @@ public class Purchase {
         return timeOfPurchase.getTimeOfPurchaseInMillisSinceEpoch();
     }
 
-    public String getTimeAgoString() {
-        return TimeFormatter.format((
-                LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-                        - getTimeOfPurchaseInMillisSinceEpoch()));
+    public LocalDateTime getTimeOfPurchaseInLocalDateTime() {
+        return LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(getTimeOfPurchaseInMillisSinceEpoch()), ZoneId.systemDefault());
     }
+
+    /**
+     * Returns "Today" plus local time if same day, else returns Day of the week plus Date.
+     */
+    public String getTimeAgoString() {
+        long daysAgo = TimeFormatter.getDaysAgo((getTimeOfPurchaseInLocalDateTime()));
+        if (daysAgo == 0) {
+            return "Today " + TimeFormatter.format12HourClock(getTimeOfPurchaseInLocalDateTime());
+        } else {
+            return TimeFormatter.formatDayPlusDate(getTimeOfPurchaseInLocalDateTime());
+        }
+    }
+
     /**
      * Returns true if both purchase have the same foodPurchased and timeOfPurchase fields.
      * This defines a stronger notion of equality between two purchases.

--- a/src/main/java/seedu/savenus/model/purchase/Purchase.java
+++ b/src/main/java/seedu/savenus/model/purchase/Purchase.java
@@ -1,8 +1,6 @@
 package seedu.savenus.model.purchase;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Objects;
 
 import seedu.savenus.model.food.Name;
@@ -39,13 +37,16 @@ public class Purchase {
         return foodPurchasedPrice;
     }
 
+    public TimeOfPurchase getTimeOfPurchase() {
+        return timeOfPurchase;
+    }
+
     public long getTimeOfPurchaseInMillisSinceEpoch() {
-        return timeOfPurchase.getTimeOfPurchaseInMillisSinceEpoch();
+        return getTimeOfPurchase().getTimeOfPurchaseInMillisSinceEpoch();
     }
 
     public LocalDateTime getTimeOfPurchaseInLocalDateTime() {
-        return LocalDateTime.ofInstant(
-                Instant.ofEpochMilli(getTimeOfPurchaseInMillisSinceEpoch()), ZoneId.systemDefault());
+        return getTimeOfPurchase().getTimeOfPurchaseInLocalDateTime();
     }
 
     /**
@@ -77,7 +78,7 @@ public class Purchase {
         Purchase otherPurchase = (Purchase) other;
         return otherPurchase.getPurchasedFoodName().equals(getPurchasedFoodName())
                 && otherPurchase.getPurchasedFoodPrice().equals(getPurchasedFoodPrice())
-                && otherPurchase.getTimeOfPurchaseInMillisSinceEpoch() == getTimeOfPurchaseInMillisSinceEpoch();
+                && otherPurchase.getTimeOfPurchase().equals(getTimeOfPurchase());
     }
 
     @Override

--- a/src/main/java/seedu/savenus/model/purchase/TimeOfPurchase.java
+++ b/src/main/java/seedu/savenus/model/purchase/TimeOfPurchase.java
@@ -1,5 +1,7 @@
 package seedu.savenus.model.purchase;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -16,6 +18,7 @@ public class TimeOfPurchase {
     private String timeOfPurchaseInMillisSinceEpochString;
 
     public TimeOfPurchase(String timeOfPurchaseInMillisSinceEpochString) {
+        requireNonNull(timeOfPurchaseInMillisSinceEpochString);
         this.timeOfPurchaseInMillisSinceEpochString = timeOfPurchaseInMillisSinceEpochString;
     }
 
@@ -23,11 +26,16 @@ public class TimeOfPurchase {
         return Long.parseLong(timeOfPurchaseInMillisSinceEpochString);
     }
 
+    public LocalDateTime getTimeOfPurchaseInLocalDateTime() {
+        return LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(getTimeOfPurchaseInMillisSinceEpoch()), ZoneId.systemDefault());
+    }
     /**
      * Check whether test string is a valid {@code TimeOfPurchase}.
      * @param testDateTimeInMillisSinceEpoch
      */
     public static boolean isValidTimeOfPurchase(String testDateTimeInMillisSinceEpoch) {
+        requireNonNull(testDateTimeInMillisSinceEpoch);
         try {
             LocalDateTime.ofInstant(Instant.ofEpochMilli(
                     Long.parseLong(testDateTimeInMillisSinceEpoch)), ZoneId.systemDefault());;
@@ -46,5 +54,19 @@ public class TimeOfPurchase {
     public static TimeOfPurchase generate() {
         return new TimeOfPurchase(
                 Long.toString(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof TimeOfPurchase)) {
+            return false;
+        }
+
+        TimeOfPurchase otherTimeOfPurchase = (TimeOfPurchase) other;
+        return otherTimeOfPurchase.getTimeOfPurchaseInMillisSinceEpoch() == getTimeOfPurchaseInMillisSinceEpoch();
     }
 }

--- a/src/main/java/seedu/savenus/model/util/TimeFormatter.java
+++ b/src/main/java/seedu/savenus/model/util/TimeFormatter.java
@@ -1,42 +1,50 @@
 package seedu.savenus.model.util;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 /**
- * Adapted from Riccardo Casatta for the idea/implementation for this class
- * https://stackoverflow.com/a/23215152/11925699
+ * Time Formatter class to format {@code LocalDateTime} input into user-readable strings.
  */
 public class TimeFormatter {
-    // Convert TimeUnits to milliseconds
-    public static final List<Long> TIMES = Arrays.asList(
-            TimeUnit.DAYS.toMillis(365),
-            TimeUnit.DAYS.toMillis(30),
-            TimeUnit.DAYS.toMillis(1));
-
-    // Map times to its corresponding string
-    public static final List<String> TIMES_STRING = Arrays.asList(
-            "year", "month", "day", "hour");
+    /**
+     * Format input duration into timeAgo format.
+     * i.e. 0 for same day, 1 for yesterday ...
+     * @param inputTimeInLocalDateTime Input time
+     */
+    public static long getDaysAgo(LocalDateTime inputTimeInLocalDateTime) {
+        LocalDate now = LocalDateTime.now(ZoneId.systemDefault()).toLocalDate();
+        LocalDate inputTimeInLocalDate = inputTimeInLocalDateTime.toLocalDate();
+        return ChronoUnit.DAYS.between(inputTimeInLocalDate, now);
+    }
 
     /**
      * Format input duration into timeAgo format.
-     * @param durationInMillis Input duration
+     * i.e. 0 for same month, 1 for last month ...
+     * @param inputTimeInLocalDateTime Input time
      */
-    public static String format(long durationInMillis) {
-        StringBuffer res = new StringBuffer();
-        // Find the largest unit of time
-        for (int i = 0; i < TimeFormatter.TIMES.size(); i++) {
-            Long current = TimeFormatter.TIMES.get(i);
-            long temp = durationInMillis / current;
-            if (temp > 0) {
-                res.append(temp).append(" ").append(TimeFormatter.TIMES_STRING.get(i))
-                    .append(temp != 1 ? "s" : "").append(" ago");
-                break;
-            }
-        }
-        return "".equals(res.toString())
-            ? "today"
-            : res.toString();
+    public static long getMonthsAgo(LocalDateTime inputTimeInLocalDateTime) {
+        LocalDate now = LocalDateTime.now(ZoneId.systemDefault()).toLocalDate();
+        LocalDate inputTimeInLocalDate = inputTimeInLocalDateTime.toLocalDate();
+        return ChronoUnit.MONTHS.between(inputTimeInLocalDate, now);
+    }
+
+    /**
+     * Format to KK:mm a.
+     * @param inputTimeInLocalDateTime
+     */
+    public static String format12HourClock(LocalDateTime inputTimeInLocalDateTime) {
+        return inputTimeInLocalDateTime.format(DateTimeFormatter.ofPattern("KK:mm a"));
+    }
+
+    /**
+     * Format to EEE, dd MMM.
+     * @param inputTimeInLocalDateTime
+     */
+    public static String formatDayPlusDate(LocalDateTime inputTimeInLocalDateTime) {
+        return inputTimeInLocalDateTime.format(DateTimeFormatter.ofPattern("EEE, dd MMM"));
     }
 }

--- a/src/main/java/seedu/savenus/model/util/TimeFormatter.java
+++ b/src/main/java/seedu/savenus/model/util/TimeFormatter.java
@@ -11,14 +11,22 @@ import java.time.temporal.ChronoUnit;
  */
 public class TimeFormatter {
     /**
-     * Format input duration into timeAgo format.
+     * Format input time and calculate the number of days until now.
      * i.e. 0 for same day, 1 for yesterday ...
      * @param inputTimeInLocalDateTime Input time
      */
     public static long getDaysAgo(LocalDateTime inputTimeInLocalDateTime) {
-        LocalDate now = LocalDateTime.now(ZoneId.systemDefault()).toLocalDate();
-        LocalDate inputTimeInLocalDate = inputTimeInLocalDateTime.toLocalDate();
-        return ChronoUnit.DAYS.between(inputTimeInLocalDate, now);
+        return getDaysAgo(inputTimeInLocalDateTime, LocalDateTime.now());
+    }
+
+    /**
+     * Format input times and compare them to get number of days between them.
+     * i.e. 0 for same day, 1 for yesterday ...
+     * @param startTimeInLocalDateTime Input time
+     */
+    public static long getDaysAgo(LocalDateTime startTimeInLocalDateTime, LocalDateTime endTimeInLocalDateTime) {
+        LocalDate inputTimeInLocalDate = startTimeInLocalDateTime.toLocalDate();
+        return ChronoUnit.DAYS.between(inputTimeInLocalDate, endTimeInLocalDateTime);
     }
 
     /**

--- a/src/main/java/seedu/savenus/model/wallet/RemainingBudget.java
+++ b/src/main/java/seedu/savenus/model/wallet/RemainingBudget.java
@@ -30,6 +30,9 @@ public class RemainingBudget {
     public RemainingBudget(String newRemainingBudgetString) {
         requireNonNull(newRemainingBudgetString);
         checkArgument(isValidRemainingBudget(newRemainingBudgetString), MESSAGE_CONSTRAINTS);
+        if (!newRemainingBudgetString.contains(".")) {
+            newRemainingBudgetString += ".00";
+        }
         remainingBudgetProperty = new SimpleStringProperty("$" + newRemainingBudgetString);
     }
 
@@ -37,11 +40,7 @@ public class RemainingBudget {
      * Returns true if a given string is a valid {@code RemainingBudget}.
      */
     public static boolean isValidRemainingBudget(String test) {
-        if (test.equals("0")) {
-            return true;
-        } else {
-            return test.matches(VALIDATION_REGEX);
-        }
+        return test.matches(VALIDATION_REGEX);
     }
 
     /**

--- a/src/main/java/seedu/savenus/ui/PurchaseCard.java
+++ b/src/main/java/seedu/savenus/ui/PurchaseCard.java
@@ -32,14 +32,14 @@ public class PurchaseCard extends UiPart<Region> {
     @FXML
     private Label price;
     @FXML
-    private Label timeago;
+    private Label timeAgo;
 
     public PurchaseCard(Purchase purchase) {
         super(FXML);
         this.purchase = purchase;
         name.setText(purchase.getPurchasedFoodName().fullName);
         price.setText("$" + purchase.getPurchasedFoodPrice());
-        timeago.setText(purchase.getTimeAgoString());
+        timeAgo.setText(purchase.getTimeAgoString());
     }
 
     @Override

--- a/src/main/resources/view/PurchaseListCard.fxml
+++ b/src/main/resources/view/PurchaseListCard.fxml
@@ -26,7 +26,7 @@
         </Label>
       </HBox>
       <Label fx:id="price" styleClass="cell_small_label" text="\$price" />
-      <Label fx:id="timeago" styleClass="cell_small_label" text="\$timeago" />
+      <Label fx:id="timeAgo" styleClass="cell_small_label" text="\$timeAgo" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/savenus/logic/commands/BuyCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/BuyCommandTest.java
@@ -2,17 +2,22 @@ package seedu.savenus.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.savenus.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.savenus.testutil.Assert.assertThrows;
 import static seedu.savenus.testutil.TypicalIndexes.INDEX_FIRST_FOOD;
 import static seedu.savenus.testutil.TypicalIndexes.INDEX_SECOND_FOOD;
-import static seedu.savenus.testutil.TypicalMenu.getPoorMenu;
+import static seedu.savenus.testutil.TypicalMenu.getTypicalMenu;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.savenus.commons.core.Messages;
-import seedu.savenus.model.Model;
-import seedu.savenus.model.ModelManager;
-import seedu.savenus.model.UserPrefs;
+import seedu.savenus.logic.commands.exceptions.CommandException;
+import seedu.savenus.model.Menu;
+import seedu.savenus.model.food.Name;
+import seedu.savenus.model.food.Price;
+import seedu.savenus.model.purchase.Purchase;
+import seedu.savenus.model.purchase.TimeOfPurchase;
+import seedu.savenus.model.wallet.Wallet;
+
+import java.util.List;
 
 
 /**
@@ -20,16 +25,42 @@ import seedu.savenus.model.UserPrefs;
  * {@code BuyCommand}.
  */
 public class BuyCommandTest {
-    // Model
-    private Model poorModel = new ModelManager(getPoorMenu(), new UserPrefs());
 
+    // Test Wallet payment
     @Test
-    public void execute_notEnoughFunds_success() {
+    public void payFoodPrice_notEnoughFunds_success() {
+        Wallet modelWallet = new Wallet("5", "100");
+        Price expensiveFoodPrice = new Price("10");
 
-        BuyCommand buyCommand = new BuyCommand(INDEX_FIRST_FOOD);
-        String expectedMessage = Messages.MESSAGE_INSUFFICIENT_FUNDS;
+        assertThrows(CommandException.class, () -> modelWallet.pay(expensiveFoodPrice));
+    }
 
-        assertCommandFailure(buyCommand, poorModel, expectedMessage);
+    // Test Wallet payment
+    @Test
+    public void payFoodPrice_enoughFunds_success() {
+        Wallet modelWallet = new Wallet("5", "100");
+        Price cheapFoodPrice = new Price("2");
+        try {
+            modelWallet.pay(cheapFoodPrice);
+        } catch (Exception e) {
+            return;
+        }
+        assertTrue(modelWallet.equals(new Wallet("3","100")));
+    }
+
+    // Test adding purchase to purchase history
+    @Test
+    public void addPurchase_success() {
+        Menu testMenu1 = new Menu(getTypicalMenu());
+        Menu testMenu2 = new Menu(getTypicalMenu());
+        Purchase testPurchase = new Purchase(new Name("testFoodName"), new Price("2"));
+        testMenu1.addPurchase(testPurchase);
+        testMenu2.setPurchaseHistory(List.of(
+                new Purchase(new Name("Ji Fan"), new Price("3.99"), new TimeOfPurchase("1570976664361")),
+                new Purchase(new Name("Wagyu steak"), new Price("50.00"), new TimeOfPurchase("1570976665687")),
+                testPurchase
+        ));
+        assertTrue(testMenu1.equals(testMenu2));
     }
 
     @Test

--- a/src/test/java/seedu/savenus/logic/commands/BuyCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/BuyCommandTest.java
@@ -2,23 +2,10 @@ package seedu.savenus.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.savenus.testutil.Assert.assertThrows;
 import static seedu.savenus.testutil.TypicalIndexes.INDEX_FIRST_FOOD;
 import static seedu.savenus.testutil.TypicalIndexes.INDEX_SECOND_FOOD;
-import static seedu.savenus.testutil.TypicalMenu.getTypicalMenu;
 
 import org.junit.jupiter.api.Test;
-
-import seedu.savenus.logic.commands.exceptions.CommandException;
-import seedu.savenus.model.Menu;
-import seedu.savenus.model.food.Name;
-import seedu.savenus.model.food.Price;
-import seedu.savenus.model.purchase.Purchase;
-import seedu.savenus.model.purchase.TimeOfPurchase;
-import seedu.savenus.model.wallet.Wallet;
-
-import java.util.List;
-
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -26,42 +13,9 @@ import java.util.List;
  */
 public class BuyCommandTest {
 
-    // Test Wallet payment
-    @Test
-    public void payFoodPrice_notEnoughFunds_success() {
-        Wallet modelWallet = new Wallet("5", "100");
-        Price expensiveFoodPrice = new Price("10");
-
-        assertThrows(CommandException.class, () -> modelWallet.pay(expensiveFoodPrice));
-    }
-
-    // Test Wallet payment
-    @Test
-    public void payFoodPrice_enoughFunds_success() {
-        Wallet modelWallet = new Wallet("5", "100");
-        Price cheapFoodPrice = new Price("2");
-        try {
-            modelWallet.pay(cheapFoodPrice);
-        } catch (Exception e) {
-            return;
-        }
-        assertTrue(modelWallet.equals(new Wallet("3","100")));
-    }
-
-    // Test adding purchase to purchase history
-    @Test
-    public void addPurchase_success() {
-        Menu testMenu1 = new Menu(getTypicalMenu());
-        Menu testMenu2 = new Menu(getTypicalMenu());
-        Purchase testPurchase = new Purchase(new Name("testFoodName"), new Price("2"));
-        testMenu1.addPurchase(testPurchase);
-        testMenu2.setPurchaseHistory(List.of(
-                new Purchase(new Name("Ji Fan"), new Price("3.99"), new TimeOfPurchase("1570976664361")),
-                new Purchase(new Name("Wagyu steak"), new Price("50.00"), new TimeOfPurchase("1570976665687")),
-                testPurchase
-        ));
-        assertTrue(testMenu1.equals(testMenu2));
-    }
+    // Due to the nature of purchases, taking in the current time, testing will be done on the wallet and purchase
+    // history separately...
+    // Please refer to the wallet and purchase history tests
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/savenus/model/purchase/PurchaseHistoryTest.java
+++ b/src/test/java/seedu/savenus/model/purchase/PurchaseHistoryTest.java
@@ -1,0 +1,82 @@
+package seedu.savenus.model.purchase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.savenus.testutil.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.savenus.model.food.Name;
+import seedu.savenus.model.food.Price;
+import seedu.savenus.model.purchase.exceptions.PurchaseNotFoundException;
+
+public class PurchaseHistoryTest {
+    private final Purchase testPurchase = new Purchase(new Name("testFoodName"), new Price("1.50"));
+    private final PurchaseHistory testPurchaseHistory = new PurchaseHistory();
+    private final List<Purchase> testListOfPurchases = new ArrayList<>(List.of(
+            new Purchase(new Name("Ji Fan"), new Price("3.99"), new TimeOfPurchase("1570976664361")),
+            new Purchase(new Name("Wagyu steak"), new Price("50.00"), new TimeOfPurchase("1570976665687"))
+    ));
+
+    @Test
+    public void add_nullPurchase_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> testPurchaseHistory.add(null));
+    }
+
+
+    @Test
+    public void remove_nullPurchase_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> testPurchaseHistory.remove(null));
+    }
+
+    @Test
+    public void remove_purchaseDoesNotExist_throwsPurchaseNotFoundException() {
+        assertThrows(PurchaseNotFoundException.class, () -> testPurchaseHistory.remove(testPurchase));
+    }
+
+    @Test
+    public void remove_existingfood_removesfood() {
+        testPurchaseHistory.add(testPurchase);
+        testPurchaseHistory.remove(testPurchase);
+        PurchaseHistory expectedPurchaseHistory = new PurchaseHistory();
+        assertEquals(expectedPurchaseHistory, testPurchaseHistory);
+    }
+
+    @Test
+    public void setPurchases_nullPurchaseHistory_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> testPurchaseHistory.setPurchases((PurchaseHistory) null));
+    }
+
+    @Test
+    public void setPurchases_purchaseHistory_replacesOwnListWithProvidedPurchaseHistory() {
+        testPurchaseHistory.add(testPurchase);
+        PurchaseHistory expectedPurchaseHistory = new PurchaseHistory();
+        expectedPurchaseHistory.add(testPurchase);
+        testPurchaseHistory.setPurchases(expectedPurchaseHistory);
+        assertEquals(expectedPurchaseHistory, testPurchaseHistory);
+    }
+
+    @Test
+    public void setPurchases_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> testPurchaseHistory.setPurchases((List<Purchase>) null));
+    }
+
+    @Test
+    public void setPurchases_list_replacesOwnListWithProvidedList() {
+        List<Purchase> purchaseList = Collections.singletonList(testPurchase);
+        testPurchaseHistory.setPurchases(purchaseList);
+        PurchaseHistory expectedPurchaseHistory = new PurchaseHistory();
+        expectedPurchaseHistory.add(testPurchase);
+        assertEquals(expectedPurchaseHistory, testPurchaseHistory);
+    }
+
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> testPurchaseHistory
+                .asUnmodifiableObservableList().remove(0));
+    }
+}

--- a/src/test/java/seedu/savenus/model/purchase/PurchaseTest.java
+++ b/src/test/java/seedu/savenus/model/purchase/PurchaseTest.java
@@ -1,0 +1,47 @@
+package seedu.savenus.model.purchase;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.savenus.testutil.TypicalMenu.NASI_LEMAK;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.savenus.model.food.Name;
+import seedu.savenus.model.food.Price;
+
+public class PurchaseTest {
+    private final String testTimeOfPurchaseInMillisSinceEpoch = "1570680000000"; // 2019/10/10 12:00:00
+    private final TimeOfPurchase testTimeOfPurchase = new TimeOfPurchase(testTimeOfPurchaseInMillisSinceEpoch);
+    private final Purchase testPurchase = new Purchase(new Name("testFoodName"), new Price("1.50"), testTimeOfPurchase);
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Purchase testPurchaseCopy = new Purchase(new Name("testFoodName"), new Price("1.50"), testTimeOfPurchase);
+        assertTrue(testPurchase.equals(testPurchaseCopy));
+
+        // same object -> returns true
+        assertTrue(testPurchase.equals(testPurchase));
+
+        // null -> returns false
+        assertFalse(testPurchase.equals(null));
+
+        // different type -> returns false
+        assertFalse(testPurchase.equals(5));
+
+        // different food -> returns false
+        assertFalse(testPurchase.equals(NASI_LEMAK));
+
+        // different name -> returns false
+        Purchase editedPurchase = new Purchase(new Name("fakeTestFoodName"), new Price("1.50"), testTimeOfPurchase);
+        assertFalse(testPurchase.equals(editedPurchase));
+
+        // different price -> returns false
+        editedPurchase = new Purchase(new Name("testFoodName"), new Price("2.50"), testTimeOfPurchase);
+        assertFalse(testPurchase.equals(editedPurchase));
+
+        // different time of purchase -> returns false
+        editedPurchase = new Purchase(new Name("testFoodName"), new Price("1.50"), TimeOfPurchase.generate());
+        assertFalse(testPurchase.equals(editedPurchase));
+    }
+}

--- a/src/test/java/seedu/savenus/model/purchase/TimeOfPurchaseTest.java
+++ b/src/test/java/seedu/savenus/model/purchase/TimeOfPurchaseTest.java
@@ -1,0 +1,28 @@
+package seedu.savenus.model.purchase;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.savenus.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TimeOfPurchaseTest {
+
+    @Test
+    public void isValidTimeOfPurchaseTest() {
+        // null name
+        assertThrows(NullPointerException.class, () -> TimeOfPurchase.isValidTimeOfPurchase(null));
+
+        // invalid remainingBudget
+        assertFalse(TimeOfPurchase.isValidTimeOfPurchase("^")); // only non-alphanumeric characters
+        assertFalse(TimeOfPurchase.isValidTimeOfPurchase("prata*")); // contains non-alphanumeric characters
+        assertFalse(TimeOfPurchase.isValidTimeOfPurchase("-123.50")); // negative remainingBudget
+        assertFalse(TimeOfPurchase.isValidTimeOfPurchase("")); // empty string
+        assertFalse(TimeOfPurchase.isValidTimeOfPurchase(" ")); // spaces only
+        assertFalse(TimeOfPurchase.isValidTimeOfPurchase("           ")); // tons of spaces
+
+        // valid remainingBudget
+        assertTrue(TimeOfPurchase.isValidTimeOfPurchase("1570680000000")); // valid remainingBudget
+    }
+
+}

--- a/src/test/java/seedu/savenus/model/util/TimeFormatterTest.java
+++ b/src/test/java/seedu/savenus/model/util/TimeFormatterTest.java
@@ -1,0 +1,23 @@
+package seedu.savenus.model.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.Test;
+
+public class TimeFormatterTest {
+
+    @Test
+    public void getDaysAgoTest() {
+        LocalDateTime testLocalDateTime = LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(Long.parseLong("1570680000000")), ZoneId.systemDefault()); // 2019/10/10 12:00:00
+
+        LocalDateTime testLocalDateTime2DaysAgo = LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(Long.parseLong("1570507200000")), ZoneId.systemDefault()); // 2019/10/08 12:00:00
+
+        assertTrue(TimeFormatter.getDaysAgo(testLocalDateTime2DaysAgo, testLocalDateTime) == 2);
+    }
+}

--- a/src/test/java/seedu/savenus/testutil/TypicalMenu.java
+++ b/src/test/java/seedu/savenus/testutil/TypicalMenu.java
@@ -107,19 +107,6 @@ public class TypicalMenu {
         return menu;
     }
 
-    public static Menu getPoorMenu() {
-        Menu menu = new Menu();
-        for (Food food : getTypicalFood()) {
-            menu.addFood(food);
-        }
-        menu.setPurchaseHistory(List.of(
-                new Purchase(new Name("Ji Fan"), new Price("3.99"), new TimeOfPurchase("1570976664361")),
-                new Purchase(new Name("Wagyu steak"), new Price("50.00"), new TimeOfPurchase("1570976665687"))
-        ));
-        menu.setWallet(new Wallet("0.00", "30"));
-        return menu;
-    }
-
     public static List<Food> getTypicalFood() {
         return new ArrayList<>(Arrays
         .asList(CARBONARA, TONKATSU_RAMEN, BAK_KUT_TEH, TEH_PING, MALA_XIANG_GUO, WAGYU_DONBURI, NASI_AYAM));


### PR DESCRIPTION
As per title.

Changes also made to `TimeFormatter`:
Purchases in purchase history will now display `TimeOfPurchase` as "Today KK:mm a" for same-day purchases, for example, "Today 10:30 pm"
Otherwise, it will display in a "EEE, dd MMM" format, for example, "Tue, 15 Oct"
