### PR TITLE
Fix MakeSort and Sort Commands

### DIFF
--- a/src/main/java/seedu/savenus/logic/commands/MakeSortCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/MakeSortCommand.java
@@ -31,4 +31,21 @@ public class MakeSortCommand extends Command {
         model.setCustomSorter(fields);
         return new CommandResult(MESSAGE_SUCCESS);
     }
+
+    public List<String> getFields() {
+        return this.fields;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj instanceof MakeSortCommand) {
+            return this.getFields().equals(((MakeSortCommand) obj).getFields());
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/savenus/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/SortCommand.java
@@ -19,6 +19,8 @@ public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
     public static final String EXAMPLE_USAGE = "Example Usage: " + COMMAND_WORD + " PRICE ASC NAME DESC";
     public static final String MESSAGE_SUCCESS = "You have successfully sorted the food items!";
+    public static final String NO_FIELDS_ERROR = "You have keyed in zero fields! "
+        + "You need to key in at least one field.";
 
     private List<String> fields;
 

--- a/src/main/java/seedu/savenus/logic/parser/FieldParser.java
+++ b/src/main/java/seedu/savenus/logic/parser/FieldParser.java
@@ -8,6 +8,7 @@ import static seedu.savenus.logic.parser.CliSyntax.FIELD_NAME_OPENING_HOURS;
 import static seedu.savenus.logic.parser.CliSyntax.FIELD_NAME_PRICE;
 import static seedu.savenus.logic.parser.CliSyntax.FIELD_NAME_RESTRICTIONS;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -19,7 +20,6 @@ import seedu.savenus.logic.parser.exceptions.ParseException;
  * Parses and Checks validity of fields.
  */
 public class FieldParser {
-    public static final String NO_ARGUMENTS_USAGE = "Note you have entered in zero arguments.";
     public static final String DUPLICATE_FIELD_USAGE = "Note you have entered a duplicate field.";
     public static final String MISSING_DIRECTION_USAGE = "Note that you need to have a direction for each field.";
     public static final String INVALID_DIRECTION_USAGE = "Note you have entered an invalid direction:\n"
@@ -32,7 +32,7 @@ public class FieldParser {
     public List<String> parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
-            throw new ParseException(NO_ARGUMENTS_USAGE);
+            return new ArrayList<String>();
         }
 
         String[] nameKeywords = trimmedArgs.split("\\s+");

--- a/src/main/java/seedu/savenus/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/savenus/logic/parser/SortCommandParser.java
@@ -18,6 +18,9 @@ public class SortCommandParser implements Parser<SortCommand> {
     public SortCommand parse(String args) throws ParseException {
         try {
             List<String> list = new FieldParser().parse(args);
+            if (list.size() == 0) {
+                throw new ParseException(SortCommand.NO_FIELDS_ERROR);
+            }
             return new SortCommand(list);
         } catch (ParseException e) {
             String message = e.getMessage();

--- a/src/test/java/seedu/savenus/logic/commands/MakeSortCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/MakeSortCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.savenus.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -19,5 +21,12 @@ public class MakeSortCommandTest {
     public void execute_correctReturnType() throws CommandException {
         MakeSortCommand test = new MakeSortCommand(fields);
         assertTrue(test.execute(model) instanceof CommandResult);
+    }
+
+    @Test
+    public void equals() {
+        assertNotEquals(new MakeSortCommand(fields), new Object());
+        MakeSortCommand test = new MakeSortCommand(fields);
+        assertEquals(test, test);
     }
 }

--- a/src/test/java/seedu/savenus/logic/parser/FieldParserTest.java
+++ b/src/test/java/seedu/savenus/logic/parser/FieldParserTest.java
@@ -43,17 +43,6 @@ public class FieldParserTest {
     }
 
     @Test
-    public void parse_emptyFields_failure() {
-        String noFieldsMessage = FieldParser.NO_ARGUMENTS_USAGE;
-
-        assertThrows(ParseException.class,
-                noFieldsMessage, () -> fieldParser.parse(""));
-
-        assertThrows(ParseException.class,
-                noFieldsMessage, () -> fieldParser.parse("  "));
-    }
-
-    @Test
     public void parse_invalidFields_failure() {
         String invalidFieldsMessage = FieldParser.INVALID_FIELD_USAGE;
 

--- a/src/test/java/seedu/savenus/logic/parser/MakeSortCommandParserTest.java
+++ b/src/test/java/seedu/savenus/logic/parser/MakeSortCommandParserTest.java
@@ -1,7 +1,8 @@
 package seedu.savenus.logic.parser;
 
-import static seedu.savenus.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.savenus.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.savenus.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,11 +12,8 @@ public class MakeSortCommandParserTest {
     private MakeSortCommandParser parser = new MakeSortCommandParser();
 
     @Test
-    public void parse_emptyFields_failure() {
-        String noFieldsMessage = FieldParser.NO_ARGUMENTS_USAGE;
-        String noFieldsUsage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                noFieldsMessage + "\n" + MakeSortCommand.EXAMPLE_USAGE);
-
-        assertParseFailure(parser, "           ", noFieldsUsage);
+    public void parse_emptyFields_success() {
+        MakeSortCommand command = new MakeSortCommand(new ArrayList<String>());
+        assertParseSuccess(parser, " ", command);
     }
 }

--- a/src/test/java/seedu/savenus/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/savenus/logic/parser/SortCommandParserTest.java
@@ -12,7 +12,7 @@ public class SortCommandParserTest {
 
     @Test
     public void parse_emptyFields_failure() {
-        String noFieldsMessage = FieldParser.NO_ARGUMENTS_USAGE;
+        String noFieldsMessage = SortCommand.NO_FIELDS_ERROR;
         String noFieldsUsage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 noFieldsMessage + "\n" + SortCommand.EXAMPLE_USAGE);
 


### PR DESCRIPTION
Allows the simple command `makesort` to override the current comparator with an empty comparator. 

Changes to `FieldParser` class are made to fit the scenario. However, `SortCommand` still does not allow for empty sort commands. Calling `sort` will still throw an error. 