### PR TITLE
Reimplementation of savings and savings history display due to revert

### DIFF
--- a/src/main/java/seedu/savenus/logic/Logic.java
+++ b/src/main/java/seedu/savenus/logic/Logic.java
@@ -11,6 +11,7 @@ import seedu.savenus.logic.parser.exceptions.ParseException;
 import seedu.savenus.model.food.Food;
 import seedu.savenus.model.menu.ReadOnlyMenu;
 import seedu.savenus.model.purchase.Purchase;
+import seedu.savenus.model.savings.ReadOnlySavingsAccount;
 import seedu.savenus.model.sort.CustomSorter;
 import seedu.savenus.model.wallet.Wallet;
 
@@ -77,4 +78,9 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the user's savings history.
+     */
+    ReadOnlySavingsAccount getSavingsHistory();
 }

--- a/src/main/java/seedu/savenus/logic/LogicManager.java
+++ b/src/main/java/seedu/savenus/logic/LogicManager.java
@@ -17,6 +17,7 @@ import seedu.savenus.model.Model;
 import seedu.savenus.model.food.Food;
 import seedu.savenus.model.menu.ReadOnlyMenu;
 import seedu.savenus.model.purchase.Purchase;
+import seedu.savenus.model.savings.ReadOnlySavingsAccount;
 import seedu.savenus.model.sort.CustomSorter;
 import seedu.savenus.model.wallet.Wallet;
 import seedu.savenus.storage.Storage;
@@ -123,5 +124,10 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public ReadOnlySavingsAccount getSavingsHistory() {
+        return model.getSavingsAccount();
     }
 }

--- a/src/main/java/seedu/savenus/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/SaveCommand.java
@@ -6,6 +6,7 @@ import seedu.savenus.logic.commands.exceptions.CommandException;
 import seedu.savenus.model.Model;
 import seedu.savenus.model.savings.Savings;
 
+//@@author fatclarence
 /**
  * Saves an amount of money into the user's savings account.
  */
@@ -19,7 +20,7 @@ public class SaveCommand extends Command {
             + "Restriction: " + Savings.MESSAGE_CONSTRAINTS + "\n"
             + "Example: " + COMMAND_WORD + " 100";
 
-    public static final String MESSAGE_SAVINGS_SUCCESS = "Current Savings: TODO @FATCLARENCE";
+    public static final String MESSAGE_SAVINGS_SUCCESS = "Added to your Savings Account: $%1$s";
 
     private final Savings savingsAmount;
 
@@ -37,6 +38,6 @@ public class SaveCommand extends Command {
         // add to the savings account in the model.
         model.addToSavings(this.savingsAmount);
 
-        return new CommandResult(String.format(MESSAGE_SAVINGS_SUCCESS));
+        return new CommandResult(String.format(MESSAGE_SAVINGS_SUCCESS, savingsAmount.toString()));
     }
 }

--- a/src/main/java/seedu/savenus/model/savings/Savings.java
+++ b/src/main/java/seedu/savenus/model/savings/Savings.java
@@ -3,6 +3,7 @@ package seedu.savenus.model.savings;
 import static java.util.Objects.requireNonNull;
 import static seedu.savenus.commons.util.AppUtil.checkArgument;
 
+//@@author fatclarence
 /**
  * Acts as the amount of money to be added into the {@code SavingsAccount} of the user
  * and also the amount of money to deduct from the {@code Wallet} of the user.

--- a/src/main/java/seedu/savenus/storage/StorageManager.java
+++ b/src/main/java/seedu/savenus/storage/StorageManager.java
@@ -211,6 +211,7 @@ public class StorageManager implements Storage {
         customSortStorage.saveFields(sorter, filePath);
     }
 
+    // =============== Savings methods ========================
 
     @Override
     public Path getSavingsAccountFilePath() {

--- a/src/main/java/seedu/savenus/ui/MainWindow.java
+++ b/src/main/java/seedu/savenus/ui/MainWindow.java
@@ -48,6 +48,7 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private InfoWindow infoWindow;
+    private SavingsHistoryPanel savingsHistoryPanel;
     private double xOffset = 0;
     private double yOffset = 0;
 
@@ -59,6 +60,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane purchaseListPanelPlaceholder;
+
+    @FXML
+    private StackPane savingsHistoryPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -100,6 +104,9 @@ public class MainWindow extends UiPart<Stage> {
 
         purchaseListPanel = new PurchaseListPanel(logic.getPurchaseHistoryList());
         purchaseListPanelPlaceholder.getChildren().add(purchaseListPanel.getRoot());
+
+        savingsHistoryPanel = new SavingsHistoryPanel(logic.getSavingsHistory().getSavingsHistory());
+        savingsHistoryPanelPlaceholder.getChildren().add(savingsHistoryPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -294,8 +301,11 @@ public class MainWindow extends UiPart<Stage> {
                 foodListPanel.showLastItem();
             }
 
-            // Update purchaseListPanel after every
+            // Update purchaseListPanel after every command.
             purchaseListPanel.updatePurchaseList(logic.getPurchaseHistoryList());
+
+            // Update savingsHistoryPanel after every command.
+            savingsHistoryPanel.updateSavingsHistory(logic.getSavingsHistory().getSavingsHistory());
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/savenus/ui/SavingsCard.java
+++ b/src/main/java/seedu/savenus/ui/SavingsCard.java
@@ -1,0 +1,53 @@
+package seedu.savenus.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.savenus.model.savings.Savings;
+
+/**
+ * An UI component that displays information of a {@code Savings}.
+ */
+public class SavingsCard extends UiPart<Region> {
+
+    private static final String FXML = "SavingsCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Savings savings;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label savingsPane;
+
+    public SavingsCard(Savings savings) {
+        super(FXML);
+        this.savings = savings;
+        savingsPane.setText("$" + savings.toString());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof SavingsCard)) {
+            return false;
+        }
+
+        // state check
+        SavingsCard card = (SavingsCard) other;
+        return savings.equals(card.savings);
+    }
+}

--- a/src/main/java/seedu/savenus/ui/SavingsHistoryPanel.java
+++ b/src/main/java/seedu/savenus/ui/SavingsHistoryPanel.java
@@ -1,0 +1,51 @@
+package seedu.savenus.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+
+import seedu.savenus.commons.core.LogsCenter;
+import seedu.savenus.model.savings.Savings;
+
+/**
+ * Panel containing the list of purchase.
+ */
+public class SavingsHistoryPanel extends UiPart<Region> {
+    private static final String FXML = "SavingsHistoryPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(SavingsHistoryPanel.class);
+
+    @FXML
+    private ListView<Savings> savingsHistoryView;
+
+    public SavingsHistoryPanel(ObservableList<Savings> savingsHistory) {
+        super(FXML);
+        savingsHistoryView.setItems(savingsHistory);
+        savingsHistoryView.setCellFactory(listView -> new SavingsHistoryViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Savings} using a {@code SavingsCard}.
+     */
+    class SavingsHistoryViewCell extends ListCell<Savings> {
+        @Override
+        protected void updateItem(Savings savings, boolean empty) {
+            super.updateItem(savings, empty);
+
+            if (empty || savings == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new SavingsCard(savings).getRoot());
+            }
+        }
+    }
+
+    public void updateSavingsHistory(ObservableList<Savings> savingsHistory) {
+        savingsHistoryView.setItems(savingsHistory);
+    }
+
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -96,75 +96,89 @@
                                             </StackPane>
                                         </VBox>
                                     </VBox>
-                           <TabPane styleClass="tab-pane-with-border" tabClosingPolicy="UNAVAILABLE">
-                             <tabs>
-                               <Tab text="History">
-                                 <content>
-                                       <VBox maxHeight="1.7976931348623157E308" prefHeight="655.0" prefWidth="670.0" spacing="10.0" styleClass="vbox-tab-pane-with-border">
-                                          <children>
-                                             <AnchorPane prefHeight="148.0" prefWidth="670.0" VBox.vgrow="NEVER">
+                           <VBox styleClass="vbox-tab-pane-with-border">
+                              <children>
+                                 <AnchorPane VBox.vgrow="ALWAYS">
+                                    <children>
+                                       <ImageView fitHeight="222.0" fitWidth="222.0" layoutX="54.0" layoutY="18.0" pickOnBounds="true" preserveRatio="true">
+                                          <image>
+                                             <Image url="@../images/Wallet.png" />
+                                          </image>
+                                       </ImageView>
+                                                  <Text fx:id="remainingBudgetPlaceholder" fill="WHITE" layoutX="204.0" layoutY="75.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="account-balance" text="money" wrappingWidth="386.0">
+                                                      <font>
+                                                          <Font name="Monospaced Regular" size="50.0" />
+                                                      </font>
+                                                  </Text>
+                                                  <Text fx:id="daysToExpirePlaceholder" fill="WHITE" layoutX="205.0" layoutY="109.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="account-days-left" text="days" wrappingWidth="174.0">
+                                                      <font>
+                                                          <Font name="Franklin Gothic Demi Cond" size="27.0" />
+                                                      </font>
+                                                  </Text>
+                                    </children>
+                                    <VBox.margin>
+                                       <Insets bottom="20.0" />
+                                    </VBox.margin>
+                                 </AnchorPane>
+                                 <TabPane styleClass="tab-pane-with-border" tabClosingPolicy="UNAVAILABLE">
+                                   <tabs>
+                                     <Tab text="History">
+                                       <content>
+                                             <VBox maxHeight="1.7976931348623157E308" prefHeight="655.0" prefWidth="670.0" spacing="10.0">
                                                 <children>
-                                                   <ImageView fitHeight="222.0" fitWidth="222.0" layoutX="54.0" layoutY="18.0" pickOnBounds="true" preserveRatio="true">
-                                                      <image>
-                                                         <Image url="@../images/Wallet.png" />
-                                                      </image>
-                                                   </ImageView>
-                                                              <Text fx:id="remainingBudgetPlaceholder" fill="WHITE" layoutX="204.0" layoutY="75.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="account-balance" text="money" wrappingWidth="386.0">
-                                                                  <font>
-                                                                      <Font name="Monospaced Regular" size="50.0" />
-                                                                  </font>
-                                                              </Text>
-                                                              <Text fx:id="daysToExpirePlaceholder" fill="WHITE" layoutX="205.0" layoutY="109.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="account-days-left" text="days" wrappingWidth="174.0">
-                                                                  <font>
-                                                                      <Font name="Franklin Gothic Demi Cond" size="27.0" />
-                                                                  </font>
-                                                              </Text>
+                                                               <Text fill="white" styleClass="purchase-history-text" text="Purchase History" textAlignment="CENTER" wrappingWidth="630.0" VBox.vgrow="NEVER">
+                                                                   <font>
+                                                                       <Font name="Franklin Gothic Demi Cond" size="40.0" />
+                                                                   </font>
+                                                               </Text>
+                                                   <VBox alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308">
+                                                      <children>
+                                                         <VBox maxHeight="1.7976931348623157E308" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                                                            <padding>
+                                                               <Insets bottom="10" left="10" right="10" top="10" />
+                                                            </padding>
+                                                            <children>
+                                                               <StackPane fx:id="purchaseListPanelPlaceholder" maxHeight="1.7976931348623157E308" VBox.vgrow="ALWAYS">
+                                                                  <VBox.margin>
+                                                                     <Insets />
+                                                                  </VBox.margin>
+                                                               </StackPane>
+                                                            </children>
+                                                         </VBox>
+                                                      </children>
+                                                   </VBox>
                                                 </children>
-                                             </AnchorPane>
-                                                         <Text fill="white" styleClass="purchase-history-text" text="Purchase History" textAlignment="CENTER" wrappingWidth="630.0" VBox.vgrow="NEVER">
-                                                             <font>
-                                                                 <Font name="Franklin Gothic Demi Cond" size="40.0" />
-                                                             </font>
-                                                         </Text>
-                                                        <VBox alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308" VBox.vgrow="ALWAYS">
-                                                            <VBox fx:id="purchaseList" maxHeight="1.7976931348623157E308" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                                                <padding>
+                                                   <Insets bottom="20.0" left="20.0" right="20.0" top="10.0" />
+                                                </padding>
+                                             </VBox>
+                                       </content>
+                                     </Tab>
+                                     <Tab closable="false" text="Savings">
+                                          <content>
+                                                        <VBox alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308">
+                                                <Text fill="white" styleClass="purchase-history-text" text="Savings History" textAlignment="CENTER" wrappingWidth="630.0">
+                                                   <font>
+                                                      <Font name="Franklin Gothic Demi Cond" size="40.0" />
+                                                   </font>
+                                                </Text>
+                                                            <VBox maxHeight="1.7976931348623157E308" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                                                                 <padding>
                                                                     <Insets bottom="10" left="10" right="10" top="10" />
                                                                 </padding>
-                                                                <StackPane fx:id="purchaseListPanelPlaceholder" maxHeight="1.7976931348623157E308" VBox.vgrow="ALWAYS">
+                                                                <StackPane fx:id="savingsHistoryPanelPlaceholder" maxHeight="1.7976931348623157E308" VBox.vgrow="ALWAYS">
                                                                     <VBox.margin>
                                                                         <Insets />
                                                                     </VBox.margin>
                                                                 </StackPane>
                                                             </VBox>
                                                         </VBox>
-                                          </children>
-                                          <padding>
-                                             <Insets bottom="20.0" left="20.0" right="20.0" top="10.0" />
-                                          </padding>
-                                       </VBox>
-                                 </content>
-                               </Tab>
-                               <Tab closable="false" text="Savings">
-                                 <content>
-                                   <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" styleClass="vbox-tab-pane-with-border">
-                                          <children>
-                                             <Text fill="WHITE" layoutX="39.0" layoutY="209.0" strokeType="OUTSIDE" strokeWidth="0.0" text="MADE YOU LOOK GOTEEM" textAlignment="CENTER" wrappingWidth="594.13671875">
-                                                <font>
-                                                   <Font name="Franklin Gothic Demi Cond" size="43.0" />
-                                                </font>
-                                             </Text>
-                                             <Text fill="WHITE" layoutX="39.0" layoutY="279.0" strokeType="OUTSIDE" strokeWidth="0.0" text="More to be added!" textAlignment="CENTER" wrappingWidth="594.13671875">
-                                                <font>
-                                                   <Font name="Franklin Gothic Demi Cond" size="43.0" />
-                                                </font>
-                                             </Text>
-                                          </children>
-                                       </AnchorPane>
-                                 </content>
-                               </Tab>
-                             </tabs>
-                           </TabPane>
+                                          </content>
+                                     </Tab>
+                                   </tabs>
+                                 </TabPane>
+                              </children>
+                           </VBox>
                                 </children>
                             </HBox>
                                <StackPane fx:id="statusbarPlaceholder" />

--- a/src/main/resources/view/SavingsCard.fxml
+++ b/src/main/resources/view/SavingsCard.fxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="300" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="80" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="savingsPane" text="\$first" styleClass="cell_big_label" >
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+            </HBox>
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/SavingsHistoryPanel.fxml
+++ b/src/main/resources/view/SavingsHistoryPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="savingsHistoryView" VBox.vgrow="ALWAYS" />
+</VBox>


### PR DESCRIPTION
Again, part of #131 , as per title.

**DONE**

Displays how much was saved by the user in the commandbox
Displays saving history in the history tab
Switch tabpane to a more intuitive position
Fix wallet display 
Make code Reposense compatible

**TODO - Immediate Priority**

Display with timestamp for savings history
Reverse the savings history when displaying for better User Experience (more intuitive that the most recent additions appear at the top)
Show total savings

Other TODOs remain in #131 .