### PR TITLE
Make ViewSortCommand

### DIFF
--- a/src/main/java/seedu/savenus/logic/commands/InfoCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/InfoCommand.java
@@ -70,6 +70,8 @@ public class InfoCommand extends Command {
 
     public static final String TOP_UP_INFO = COMMAND_INDICATOR + TopUpCommand.COMMAND_WORD;
 
+    public static final String VIEW_SORT_INFO = COMMAND_INDICATOR + ViewSortCommand.COMMAND_WORD;
+
     public static final String INVALID_COMMAND_ENTERED_MESSAGE = "Sorry, no information for such command exists!";
 
     public static final String MULTIPLE_COMMAND_ENTERED_MESSAGE =
@@ -143,6 +145,8 @@ public class InfoCommand extends Command {
             return new CommandResult(SORT_INFO);
         case TopUpCommand.COMMAND_WORD :
             return new CommandResult(TOP_UP_INFO);
+        case ViewSortCommand.COMMAND_WORD :
+            return new CommandResult(VIEW_SORT_INFO);
         default :
             throw new CommandException(INVALID_COMMAND_ENTERED_MESSAGE);
         }

--- a/src/main/java/seedu/savenus/logic/commands/ViewSortCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/ViewSortCommand.java
@@ -1,0 +1,22 @@
+package seedu.savenus.logic.commands;
+
+import seedu.savenus.model.Model;
+
+/**
+ * Allows the user to view the current Custom Sorter.
+ */
+public class ViewSortCommand extends Command {
+    public static final String COMMAND_WORD = "viewsort";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views the current Custom Sorter.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String VIEW_COMMAND_SUCCESS = "Here are the fields specified for your CustomSorter: \n"
+            + "%s";
+
+    @Override
+    public CommandResult execute(Model model) {
+        String customSorterAsString = model.getCustomSorter().toString();
+        return new CommandResult(String.format(VIEW_COMMAND_SUCCESS, customSorterAsString));
+    }
+}

--- a/src/main/java/seedu/savenus/logic/parser/SaveNusParser.java
+++ b/src/main/java/seedu/savenus/logic/parser/SaveNusParser.java
@@ -35,6 +35,7 @@ import seedu.savenus.logic.commands.SaveCommand;
 import seedu.savenus.logic.commands.SortCommand;
 
 import seedu.savenus.logic.commands.TopUpCommand;
+import seedu.savenus.logic.commands.ViewSortCommand;
 import seedu.savenus.logic.parser.exceptions.ParseException;
 
 /**
@@ -145,6 +146,9 @@ public class SaveNusParser {
 
         case AutoSortCommand.COMMAND_WORD:
             return new AutoSortCommandParser().parse(arguments);
+
+        case ViewSortCommand.COMMAND_WORD:
+            return new ViewSortCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/savenus/model/info/ViewSortInfo.java
+++ b/src/main/java/seedu/savenus/model/info/ViewSortInfo.java
@@ -1,0 +1,18 @@
+package seedu.savenus.model.info;
+
+import seedu.savenus.logic.commands.ViewSortCommand;
+
+/**
+ * Contains information on View Sort command.
+ */
+public class ViewSortInfo {
+    public static final String COMMAND_WORD = ViewSortCommand.COMMAND_WORD;
+
+    public static final String INFORMATION = "View Sort command allows you to view the fields"
+            + " specified for your CustomSorter.";
+
+    public static final String USAGE = ViewSortCommand.COMMAND_WORD;
+
+    public static final String OUTPUT = "Here are the fields specified for your CustomSorter: \n"
+            + "Fields will be specified on this line.";
+}

--- a/src/main/java/seedu/savenus/model/sort/FoodComparator.java
+++ b/src/main/java/seedu/savenus/model/sort/FoodComparator.java
@@ -66,12 +66,16 @@ public class FoodComparator implements Comparator<Food> {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
+        if (fieldList.isEmpty()) {
+            return "No fields specified.";
+        } else {
+            StringBuilder sb = new StringBuilder();
 
-        for (String field : fieldList) {
-            sb.append(field + " ");
+            for (String field : fieldList) {
+                sb.append(field + " ");
+            }
+
+            return sb.toString();
         }
-
-        return sb.toString();
     }
 }

--- a/src/main/java/seedu/savenus/ui/InfoWindow.java
+++ b/src/main/java/seedu/savenus/ui/InfoWindow.java
@@ -36,6 +36,7 @@ import seedu.savenus.model.info.RemoveLikeInfo;
 import seedu.savenus.model.info.SaveInfo;
 import seedu.savenus.model.info.SortInfo;
 import seedu.savenus.model.info.TopUpInfo;
+import seedu.savenus.model.info.ViewSortInfo;
 
 /**
  * Controller for a info page
@@ -286,6 +287,12 @@ public class InfoWindow extends UiPart<Stage> {
             infoMessage.setText(TopUpInfo.INFORMATION);
             usageExample.setText(TopUpInfo.USAGE);
             output.setText(TopUpInfo.OUTPUT);
+            break;
+        case InfoCommand.VIEW_SORT_INFO :
+            commandWord.setText(ViewSortInfo.COMMAND_WORD);
+            infoMessage.setText(ViewSortInfo.INFORMATION);
+            usageExample.setText(ViewSortInfo.USAGE);
+            output.setText(ViewSortInfo.OUTPUT);
             break;
         default :
             commandWord.setText("YOU ARE NOT SUP  POSED TO SEE TH IS PAG  E");

--- a/src/test/java/seedu/savenus/logic/commands/InfoCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/InfoCommandTest.java
@@ -148,6 +148,10 @@ public class InfoCommandTest {
         expectedCommandResult =
                 new CommandResult(InfoCommand.SORT_INFO, false, false, false);
         assertCommandSuccess(new InfoCommand("sort"), model, expectedCommandResult, expectedModel);
+
+        expectedCommandResult =
+                new CommandResult(InfoCommand.VIEW_SORT_INFO, false, false, false);
+        assertCommandSuccess(new InfoCommand("viewsort"), model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/savenus/logic/commands/ViewSortCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/ViewSortCommandTest.java
@@ -1,0 +1,21 @@
+package seedu.savenus.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.savenus.model.Model;
+import seedu.savenus.model.ModelManager;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code ViewSortCommand}.
+ */
+public class ViewSortCommandTest {
+    private Model model = new ModelManager();
+
+    @Test
+    public void execute_correctReturnType() {
+        ViewSortCommand test = new ViewSortCommand();
+        assertTrue(test.execute(model) instanceof CommandResult);
+    }
+}

--- a/src/test/java/seedu/savenus/logic/parser/SaveNusParserTest.java
+++ b/src/test/java/seedu/savenus/logic/parser/SaveNusParserTest.java
@@ -41,6 +41,7 @@ import seedu.savenus.logic.commands.MakeSortCommand;
 import seedu.savenus.logic.commands.RecommendCommand;
 import seedu.savenus.logic.commands.SaveCommand;
 import seedu.savenus.logic.commands.SortCommand;
+import seedu.savenus.logic.commands.ViewSortCommand;
 import seedu.savenus.logic.parser.exceptions.ParseException;
 import seedu.savenus.model.food.Food;
 import seedu.savenus.model.food.NameContainsKeywordsPredicate;
@@ -199,6 +200,12 @@ public class SaveNusParserTest {
     public void parseCommand_autosort() throws ParseException {
         assertTrue(
                 parser.parseCommand(AutoSortCommand.COMMAND_WORD + " ON") instanceof AutoSortCommand);
+    }
+
+    @Test
+    public void parseCommand_viewsort() throws ParseException {
+        assertTrue(
+                parser.parseCommand(ViewSortCommand.COMMAND_WORD) instanceof ViewSortCommand);
     }
 
     @Test


### PR DESCRIPTION
Created a new `viewsort` command, where users are allowed to view the fields of the current `CustomSorter`, if any. 

Also, added InfoCard for the new `viewsort` command. 

TODO: Add `viewsort` for User Guide and Developer Guide and PPP. 