### PR TITLE
Fix Parsing of Duplicate Fields for AddCommand and EditCommand

### DIFF
--- a/src/main/java/seedu/savenus/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/savenus/logic/parser/AddCommandParser.java
@@ -48,28 +48,23 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         // Name and price are required fields
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Price price = ParserUtil.parsePrice(argMultimap.getValue(PREFIX_PRICE).get());
-        Category category = ParserUtil.parseCategory(argMultimap.getValue(PREFIX_CATEGORY).get());
+        Name name = ParserUtil.parseTheNames(argMultimap.getAllValues(PREFIX_NAME));
+        Price price = ParserUtil.parseThePrices(argMultimap.getAllValues(PREFIX_PRICE));
+        Category category = ParserUtil.parseTheCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 
         // Description is an optional field
-        Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION)
-                .orElse(Description.DEFAULT_VALUE));
+        Description description = ParserUtil.parseTheDescriptions(argMultimap.getAllValues(PREFIX_DESCRIPTION));
 
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         // Location is an optional field
-        Location location = ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION)
-                .orElse(Location.DEFAULT_VALUE));
+        Location location = ParserUtil.parseTheLocations(argMultimap.getAllValues(PREFIX_LOCATION));
 
         // Opening Hours is an optional field.
-        OpeningHours openingHours = ParserUtil.parseOpeningHours(argMultimap.getValue(PREFIX_OPENING_HOURS)
-                .orElse(OpeningHours.DEFAULT_VALUE));
+        OpeningHours openingHours = ParserUtil.parseTheOpeningHours(argMultimap.getAllValues(PREFIX_OPENING_HOURS));
 
         // Restriction is an optional field.
-        Restrictions restrictions = ParserUtil.parseRestrictions(argMultimap.getValue(PREFIX_RESTRICTIONS)
-                .orElse(Restrictions.DEFAULT_VALUE));
-
+        Restrictions restrictions = ParserUtil.parseTheRestrictions(argMultimap.getAllValues(PREFIX_RESTRICTIONS));
 
         Food food = new Food(name, price, description, category, tagList, location, openingHours, restrictions);
 

--- a/src/main/java/seedu/savenus/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/savenus/logic/parser/EditCommandParser.java
@@ -48,30 +48,30 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditFoodDescriptor editFoodDescriptor = new EditFoodDescriptor();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editFoodDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            editFoodDescriptor.setName(ParserUtil.parseTheNames(argMultimap.getAllValues(PREFIX_NAME)));
         }
         if (argMultimap.getValue(PREFIX_PRICE).isPresent()) {
-            editFoodDescriptor.setPrice(ParserUtil.parsePrice(argMultimap.getValue(PREFIX_PRICE).get()));
+            editFoodDescriptor.setPrice(ParserUtil.parseThePrices(argMultimap.getAllValues(PREFIX_PRICE)));
         }
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
-            editFoodDescriptor.setDescription(ParserUtil.parseDescription(argMultimap
-                    .getValue(PREFIX_DESCRIPTION).get()));
+            editFoodDescriptor.setDescription(
+                    ParserUtil.parseTheDescriptions(argMultimap.getAllValues(PREFIX_DESCRIPTION)));
         }
         if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
-            editFoodDescriptor.setCategory(ParserUtil.parseCategory(argMultimap
-                    .getValue(PREFIX_CATEGORY).get()));
+            editFoodDescriptor.setCategory(
+                    ParserUtil.parseTheCategories(argMultimap.getAllValues(PREFIX_CATEGORY)));
         }
         if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
-            editFoodDescriptor.setLocation(ParserUtil.parseLocation(argMultimap
-                    .getValue(PREFIX_LOCATION).get()));
+            editFoodDescriptor.setLocation(
+                    ParserUtil.parseTheLocations(argMultimap.getAllValues(PREFIX_LOCATION)));
         }
         if (argMultimap.getValue(PREFIX_OPENING_HOURS).isPresent()) {
-            editFoodDescriptor.setOpeningHours(ParserUtil.parseOpeningHours(argMultimap
-                    .getValue(PREFIX_OPENING_HOURS).get()));
+            editFoodDescriptor.setOpeningHours(
+                    ParserUtil.parseTheOpeningHours(argMultimap.getAllValues(PREFIX_OPENING_HOURS)));
         }
         if (argMultimap.getValue(PREFIX_RESTRICTIONS).isPresent()) {
-            editFoodDescriptor.setRestrictions(ParserUtil.parseRestrictions(argMultimap
-                    .getValue(PREFIX_RESTRICTIONS).get()));
+            editFoodDescriptor.setRestrictions(
+                    ParserUtil.parseTheRestrictions(argMultimap.getAllValues(PREFIX_RESTRICTIONS)));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editFoodDescriptor::setTags);
 

--- a/src/main/java/seedu/savenus/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/savenus/logic/parser/ParserUtil.java
@@ -35,7 +35,8 @@ import seedu.savenus.model.wallet.Wallet;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String DUPLICATE_FIELDS = "You have multiple instances of %s.";
+    public static final String DUPLICATE_FIELDS = "You have multiple instances of %s. \n"
+            + "Please make sure you only have one instance of it.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/savenus/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/savenus/logic/parser/ParserUtil.java
@@ -35,6 +35,7 @@ import seedu.savenus.model.wallet.Wallet;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String DUPLICATE_FIELDS = "You have multiple instances of %s.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -151,6 +152,31 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a collection of {@code String names} into a {@code Name}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid or multiple names are present.
+     */
+    public static Name parseTheNames(Collection<String> names) throws ParseException {
+        requireNonNull(names);
+        if (names.size() > 1) {
+            throw new ParseException(String.format(DUPLICATE_FIELDS, "Name"));
+        }
+
+        String theName = "";
+        for (String name : names) {
+            if (!Name.isValidName(name.trim())) {
+                throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            }
+
+            theName = name.trim();
+            break;
+        }
+
+        return new Name(theName);
+    }
+
+    /**
      * Parses a {@code String price} into a {@code Price}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -163,6 +189,31 @@ public class ParserUtil {
             throw new ParseException(Price.MESSAGE_CONSTRAINTS);
         }
         return new Price(trimmedPrice);
+    }
+
+    /**
+     * Parses a collection of {@code String prices} into a {@code Price}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid or multiple prices are present.
+     */
+    public static Price parseThePrices(Collection<String> prices) throws ParseException {
+        requireNonNull(prices);
+        if (prices.size() > 1) {
+            throw new ParseException(String.format(DUPLICATE_FIELDS, "Price"));
+        }
+
+        String thePrice = "";
+        for (String price : prices) {
+            if (!Price.isValidPrice(price)) {
+                throw new ParseException(Price.MESSAGE_CONSTRAINTS);
+            }
+
+            thePrice = price;
+            break;
+        }
+
+        return new Price(thePrice);
     }
 
     /**
@@ -181,6 +232,31 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a collection of {@code String categories} into a {@code Category}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid or multiple categories are present.
+     */
+    public static Category parseTheCategories(Collection<String> categories) throws ParseException {
+        requireNonNull(categories);
+        if (categories.size() > 1) {
+            throw new ParseException(String.format(DUPLICATE_FIELDS, "Category"));
+        }
+
+        String theCategory = "";
+        for (String category : categories) {
+            if (!Category.isValidCategory(category)) {
+                throw new ParseException(Category.MESSAGE_CONSTRAINTS);
+            }
+
+            theCategory = category;
+            break;
+        }
+
+        return new Category(theCategory);
+    }
+
+    /**
      * Parses a {@code String description} into an {@code description}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -196,6 +272,36 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a collection of {@code String descriptions} into a {@code Description}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid or multiple descriptions are present.
+     */
+    public static Description parseTheDescriptions(Collection<String> descriptions) throws ParseException {
+        requireNonNull(descriptions);
+        if (descriptions.size() > 1) {
+            throw new ParseException(String.format(DUPLICATE_FIELDS, "Description"));
+        }
+
+        if (descriptions.size() == 0) {
+            return new Description(Description.DEFAULT_VALUE);
+        }
+
+        String theDescription = "";
+
+        for (String description : descriptions) {
+            if (!Description.isValidDescription(description)) {
+                throw new ParseException(Description.MESSAGE_CONSTRAINTS);
+            }
+
+            theDescription = description;
+            break;
+        }
+
+        return new Description(theDescription);
+    }
+
+    /**
      * Parses a {@code String location} into an {@code location}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -208,6 +314,36 @@ public class ParserUtil {
             throw new ParseException(Location.MESSAGE_CONSTRAINTS);
         }
         return new Location(trimmedLocation);
+    }
+
+    /**
+     * Parses a collection of {@code String locations} into a {@code Location}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid or multiple locations are present.
+     */
+    public static Location parseTheLocations(Collection<String> locations) throws ParseException {
+        requireNonNull(locations);
+        if (locations.size() > 1) {
+            throw new ParseException(String.format(DUPLICATE_FIELDS, "Location"));
+        }
+
+        if (locations.size() == 0) {
+            return new Location(Location.DEFAULT_VALUE);
+        }
+
+        String theLocation = "";
+
+        for (String location : locations) {
+            if (!Location.isValidLocation(location)) {
+                throw new ParseException(Location.MESSAGE_CONSTRAINTS);
+            }
+
+            theLocation = location;
+            break;
+        }
+
+        return new Location(theLocation);
     }
 
     /**
@@ -229,6 +365,36 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a collection of {@code String openingHours} into a {@code OpeningHours}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid or multiple openingHours are present.
+     */
+    public static OpeningHours parseTheOpeningHours(Collection<String> openingHours) throws ParseException {
+        requireNonNull(openingHours);
+        if (openingHours.size() > 1) {
+            throw new ParseException(String.format(DUPLICATE_FIELDS, "OpeningHours"));
+        }
+
+        if (openingHours.size() == 0) {
+            return new OpeningHours(OpeningHours.DEFAULT_VALUE);
+        }
+
+        String theOpeningHours = "";
+
+        for (String actualOpeningHours : openingHours) {
+            if (!OpeningHours.isValidOpeningHours(actualOpeningHours)) {
+                throw new ParseException(OpeningHours.MESSAGE_CONSTRAINTS);
+            }
+
+            theOpeningHours = actualOpeningHours;
+            break;
+        }
+
+        return new OpeningHours(theOpeningHours);
+    }
+
+    /**
      * Parse a {@code String restrictions} into an {@code restrictions}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -241,6 +407,36 @@ public class ParserUtil {
             throw new ParseException(Restrictions.MESSAGE_CONSTRAINTS);
         }
         return new Restrictions(trimmedRestrictions);
+    }
+
+    /**
+     * Parses a collection of {@code String restrictions} into a {@code Restrictions}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid or multiple restrictions are present.
+     */
+    public static Restrictions parseTheRestrictions(Collection<String> restrictions) throws ParseException {
+        requireNonNull(restrictions);
+        if (restrictions.size() > 1) {
+            throw new ParseException(String.format(DUPLICATE_FIELDS, "Restrictions"));
+        }
+
+        if (restrictions.size() == 0) {
+            return new Restrictions(Restrictions.DEFAULT_VALUE);
+        }
+
+        String theRestriction = "";
+
+        for (String restriction : restrictions) {
+            if (!Restrictions.isValidRestrictions(restriction)) {
+                throw new ParseException(Restrictions.MESSAGE_CONSTRAINTS);
+            }
+
+            theRestriction = restriction;
+            break;
+        }
+
+        return new Restrictions(theRestriction);
     }
 
     /**

--- a/src/test/java/seedu/savenus/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/savenus/logic/parser/AddCommandParserTest.java
@@ -59,33 +59,33 @@ public class AddCommandParserTest {
                 + LOCATION_DESC_NASI_LEMAK + OPENING_HOURS_DESC_NASI_LEMAK
                 + RESTRICTIONS_DESC_NASI_LEMAK, new AddCommand(expectedFood));
 
-        // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_CHICKEN_RICE + NAME_DESC_NASI_LEMAK
+        // multiple names not success
+        assertParseFailure(parser, NAME_DESC_CHICKEN_RICE + NAME_DESC_NASI_LEMAK
                 + PRICE_DESC_NASI_LEMAK + DESCRIPTION_DESC_NASI_LEMAK
                 + CATEGORY_DESC_NASI_LEMAK + TAG_DESC_CHICKEN
                 + LOCATION_DESC_NASI_LEMAK + OPENING_HOURS_DESC_NASI_LEMAK
-                + RESTRICTIONS_DESC_NASI_LEMAK, new AddCommand(expectedFood));
+                + RESTRICTIONS_DESC_NASI_LEMAK, String.format(ParserUtil.DUPLICATE_FIELDS, "Name"));
 
-        // multiple prices - last price accepted
-        assertParseSuccess(parser, NAME_DESC_NASI_LEMAK + PRICE_DESC_CHICKEN_RICE
+        // multiple prices not success
+        assertParseFailure(parser, NAME_DESC_NASI_LEMAK + PRICE_DESC_CHICKEN_RICE
                 + PRICE_DESC_NASI_LEMAK + DESCRIPTION_DESC_NASI_LEMAK
                 + CATEGORY_DESC_NASI_LEMAK + TAG_DESC_CHICKEN
                 + LOCATION_DESC_NASI_LEMAK + OPENING_HOURS_DESC_NASI_LEMAK
-                + RESTRICTIONS_DESC_NASI_LEMAK, new AddCommand(expectedFood));
+                + RESTRICTIONS_DESC_NASI_LEMAK, String.format(ParserUtil.DUPLICATE_FIELDS, "Price"));
 
-        // multiple descriptions - last description accepted
-        assertParseSuccess(parser, NAME_DESC_NASI_LEMAK + PRICE_DESC_NASI_LEMAK
+        // multiple descriptions not success
+        assertParseFailure(parser, NAME_DESC_NASI_LEMAK + PRICE_DESC_NASI_LEMAK
                 + DESCRIPTION_DESC_CHICKEN_RICE + DESCRIPTION_DESC_NASI_LEMAK
                 + CATEGORY_DESC_NASI_LEMAK + TAG_DESC_CHICKEN
                 + LOCATION_DESC_NASI_LEMAK + OPENING_HOURS_DESC_NASI_LEMAK
-                + RESTRICTIONS_DESC_NASI_LEMAK, new AddCommand(expectedFood));
+                + RESTRICTIONS_DESC_NASI_LEMAK, String.format(ParserUtil.DUPLICATE_FIELDS, "Description"));
 
-        // multiple locations - last location accepted
-        assertParseSuccess(parser, NAME_DESC_NASI_LEMAK + PRICE_DESC_NASI_LEMAK
+        // multiple locations not success
+        assertParseFailure(parser, NAME_DESC_NASI_LEMAK + PRICE_DESC_NASI_LEMAK
                 + DESCRIPTION_DESC_NASI_LEMAK + CATEGORY_DESC_NASI_LEMAK
                 + TAG_DESC_CHICKEN
                 + LOCATION_DESC_CHICKEN_RICE + LOCATION_DESC_NASI_LEMAK + OPENING_HOURS_DESC_NASI_LEMAK
-                + RESTRICTIONS_DESC_NASI_LEMAK, new AddCommand(expectedFood));
+                + RESTRICTIONS_DESC_NASI_LEMAK, String.format(ParserUtil.DUPLICATE_FIELDS, "Location"));
 
         // multiple tags - all accepted
         Food expectedFoodMultipleTags = new FoodBuilder(NASI_LEMAK).withTags(VALID_TAG_CHICKEN, VALID_TAG_RICE)

--- a/src/test/java/seedu/savenus/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/savenus/logic/parser/EditCommandParserTest.java
@@ -96,16 +96,7 @@ public class EditCommandParserTest {
         // valid price followed by invalid price. The test case for invalid price followed by valid price
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + PRICE_DESC_NASI_LEMAK
-            + INVALID_PRICE_DESC, Price.MESSAGE_CONSTRAINTS);
-
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Food} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_RICE + TAG_DESC_CHICKEN
-            + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_RICE + TAG_EMPTY
-            + TAG_DESC_CHICKEN, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_RICE
-            + TAG_DESC_CHICKEN, Tag.MESSAGE_CONSTRAINTS);
+            + INVALID_PRICE_DESC, String.format(ParserUtil.DUPLICATE_FIELDS, "Price"));
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC
@@ -181,7 +172,7 @@ public class EditCommandParserTest {
     }
 
     @Test
-    public void parse_multipleRepeatedFields_acceptsLast() {
+    public void parse_multipleRepeatedFields_rejected() {
         Index targetIndex = INDEX_FIRST_FOOD;
         String userInput = targetIndex.getOneBased() + PRICE_DESC_CHICKEN_RICE + DESCRIPTION_DESC_CHICKEN_RICE
                 + TAG_DESC_RICE + PRICE_DESC_CHICKEN_RICE + DESCRIPTION_DESC_CHICKEN_RICE + TAG_DESC_RICE
@@ -192,17 +183,17 @@ public class EditCommandParserTest {
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
-        assertParseSuccess(parser, userInput, expectedCommand);
+        assertParseFailure(parser, userInput, String.format(ParserUtil.DUPLICATE_FIELDS, "Price"));
     }
 
     @Test
-    public void parse_invalidValueFollowedByValidValue_success() {
+    public void parse_invalidValueFollowedByValidValue_failure() {
         // no other valid values specified
         Index targetIndex = INDEX_FIRST_FOOD;
         String userInput = targetIndex.getOneBased() + INVALID_PRICE_DESC + PRICE_DESC_NASI_LEMAK;
         EditFoodDescriptor descriptor = new EditFoodDescriptorBuilder().withPrice(VALID_PRICE_NASI_LEMAK).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
+        assertParseFailure(parser, userInput, String.format(ParserUtil.DUPLICATE_FIELDS, "Price"));
         // other valid values specified
         userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_NASI_LEMAK + INVALID_PRICE_DESC
                 + PRICE_DESC_NASI_LEMAK;
@@ -210,7 +201,7 @@ public class EditCommandParserTest {
                 .withPrice(VALID_PRICE_NASI_LEMAK).withDescription(VALID_DESCRIPTION_NASI_LEMAK)
                 .build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
+        assertParseFailure(parser, userInput, String.format(ParserUtil.DUPLICATE_FIELDS, "Price"));
     }
 
     @Test


### PR DESCRIPTION
Previously, users are allowed to key in duplicate fields for `AddCommand` and `EditCommand` and the parser will usually take the last instance. 

Now, an error message will pop up on the inspection of duplicate fields. 