### PR TITLE
Remove h for HistoryCommand

### DIFF
--- a/src/main/java/seedu/savenus/logic/commands/HistoryCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/HistoryCommand.java
@@ -14,7 +14,6 @@ import seedu.savenus.model.Model;
 public class HistoryCommand extends Command {
 
     public static final String COMMAND_WORD = "history";
-    public static final String COMMAND_ALIAS = "h";
 
     public static final String MESSAGE_SUCCESS = "You have entered these commands:\n";
     public static final String MESSAGE_NO_HISTORY = "You have not entered any commands.";

--- a/src/main/java/seedu/savenus/logic/parser/SaveNusParser.java
+++ b/src/main/java/seedu/savenus/logic/parser/SaveNusParser.java
@@ -114,7 +114,6 @@ public class SaveNusParser {
         case DefaultCommand.COMMAND_WORD:
             return new DefaultCommand();
 
-        case HistoryCommand.COMMAND_ALIAS:
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();
 


### PR DESCRIPTION
Given that you are allowed to create `ALIASWORD` for `COMMANDWORD` such as `history`, there is no such need for the alias `h` for `HistoryCommand`