### PR TITLE
Fix Sorting and Recommendation Dependencies

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -663,6 +663,7 @@ image::recommend.png[]
 
 [NOTE]
 To clear the recommendations, use the `list` or `add` command.
+Recommendations will be cleared too using specific sorting commands such as `sort`.
 
 [NOTE]
 The recommended amount to spend per meal is calculated by `budget / (daysToExpiry * 2)` under the assumption that the

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -645,6 +645,9 @@ The factors affecting the calculation of the recommendation value is summarized 
 |===
 //end::recommendationpenalty[]
 
+[IMPORTANT]
+Recommendation turns auto-sorting OFF.
+
 ****
 Format: `recommend`
 ****

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -290,6 +290,9 @@ Sorts all the food items by some specific FIELD.
 
 Note: You can have more than one pair of FIELD and DIRECTION.
 
+[IMPORTANT]
+The usage of `sort` will turn the recommendation system OFF it is in use.
+
 ****
 *Format*: `sort FIELD DIRECTION ...` +
 *Example*: `sort PRICE ASC`
@@ -327,6 +330,9 @@ image::makesortsuccess.png[]
 ==== Sort based on your custom comparator: `customsort`
 Sort Using your own custom comparator, which you have creating from MakeSort.
 
+[IMPORTANT]
+The usage of `customsort` will turn the recommendation system OFF it is in use.
+
 ****
 *Format*: `customsort`
 ****
@@ -344,6 +350,9 @@ image::customsortsuccess.png[]
 ==== Auto sorts list based on custom comparator: `autosort`
 Turns on and off auto sorting, based on your own custom comparator, every time you make changes to the food list.
 There are only two states, ON or OFF.
+
+[IMPORTANT]
+The usage of `autosort` will turn the recommendation system OFF it is in use.
 
 ****
 *Format*: `autosort STATE` +
@@ -384,6 +393,9 @@ image::viewsortsuccess.png[]
 
 ==== Sorts food items based on natural order: `default`
 Sorts the food items based on their default ordering, where it is based on ascending category, name and then price.
+
+[IMPORTANT]
+The usage of `default` will turn the recommendation system OFF it is in use.
 
 ****
 *Format*: `default`

--- a/src/main/java/seedu/savenus/logic/commands/AutoSortCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/AutoSortCommand.java
@@ -30,6 +30,10 @@ public class AutoSortCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         if (shouldAutoSort) {
+
+            // Clear the recommendation system (if it was used)
+            model.setRecommendationSystemInUse(false);
+
             model.setAutoSortFlag(true);
             String customSorterAsString = model.getCustomSorter().toString();
             return new CommandResult(String.format(AUTO_SORT_ON_MESSAGE_SUCCESS, customSorterAsString));

--- a/src/main/java/seedu/savenus/logic/commands/CustomSortCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/CustomSortCommand.java
@@ -25,6 +25,11 @@ public class CustomSortCommand extends Command {
         if (model.getAutoSortFlag() == true) {
             return new CommandResult(AUTO_SORT_WARNING);
         }
+
+        // Clear the recommendation system (if it was used)
+        model.setRecommendationSystemInUse(false);
+
+
         ObservableList<Food> foodList = model.getFilteredFoodList();
         CustomSorter sorter = model.getCustomSorter();
         SortedList<Food> sortedList = foodList.sorted(sorter.getComparator());

--- a/src/main/java/seedu/savenus/logic/commands/DefaultCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/DefaultCommand.java
@@ -27,6 +27,10 @@ public class DefaultCommand extends Command {
         if (model.getAutoSortFlag() == true) {
             return new CommandResult(AUTO_SORT_WARNING);
         }
+
+        // Clear the recommendation system (if it was used)
+        model.setRecommendationSystemInUse(false);
+
         ObservableList<Food> foodList = model.getFilteredFoodList();
         SortedList<Food> sortedList = foodList.sorted(new DefaultComparator());
         model.setFoods(sortedList);

--- a/src/main/java/seedu/savenus/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/FilterCommand.java
@@ -35,6 +35,10 @@ public class FilterCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        // Clear the recommendation system (if it was used)
+        model.setRecommendationSystemInUse(false);
+
         model.editFilteredFoodList(fields);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/savenus/logic/commands/RecommendCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/RecommendCommand.java
@@ -26,6 +26,9 @@ public class RecommendCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
+        // Turns auto-sorting off while recommending food items
+        model.setAutoSortFlag(false);
+
         model.setRecommendationSystemInUse(true);
 
         RecommendationSystem recInstance = RecommendationSystem.getInstance();

--- a/src/main/java/seedu/savenus/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/SortCommand.java
@@ -45,6 +45,10 @@ public class SortCommand extends Command {
         if (model.getAutoSortFlag() == true) {
             return new CommandResult(AUTO_SORT_WARNING);
         }
+
+        // Clear the recommendation system (if it was used)
+        model.setRecommendationSystemInUse(false);
+
         ObservableList<Food> foodList = model.getFilteredFoodList();
         SortedList<Food> sortedList = foodList.sorted(new FoodComparator(fields));
         model.setFoods(sortedList);


### PR DESCRIPTION
`recommend` now turns auto-sorting off. 

`default`, `customsort`, `autosort` and `sort` turns the recommendation system off. 

Fixes #303