### PR TITLE
Fix Addition and Editing of Identical Foods

### DIFF
--- a/src/main/java/seedu/savenus/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/savenus/logic/commands/EditCommand.java
@@ -57,7 +57,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_FOOD_SUCCESS = "Edited Food: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field of the food to be edited must be provided.";
-    public static final String MESSAGE_DUPLICATE_FOOD = "This food already exists in the menu.";
+    public static final String MESSAGE_DUPLICATE_FOOD = "This food name already exists in the menu.";
 
     private final Index index;
     private final EditFoodDescriptor editFoodDescriptor;

--- a/src/main/java/seedu/savenus/model/food/Food.java
+++ b/src/main/java/seedu/savenus/model/food/Food.java
@@ -122,7 +122,7 @@ public class Food {
         }
 
         return otherFood != null
-                && otherFood.getName().equals(getName());
+                && otherFood.equals(this);
     }
 
     /**
@@ -140,7 +140,11 @@ public class Food {
         }
 
         Food otherFood = (Food) other;
-        return otherFood.getName().equals(getName());
+        return otherFood.getName().equals(getName())
+                && (otherFood.getDescription().equals(getDescription())
+                        && otherFood.getLocation().equals(getLocation())
+                        && otherFood.getRestrictions().equals(getRestrictions())
+                        && otherFood.getOpeningHours().equals(getOpeningHours()));
     }
 
     @Override

--- a/src/main/java/seedu/savenus/model/food/Food.java
+++ b/src/main/java/seedu/savenus/model/food/Food.java
@@ -122,13 +122,7 @@ public class Food {
         }
 
         return otherFood != null
-                && otherFood.getName().equals(getName())
-                && otherFood.getPrice().equals(getPrice())
-                && otherFood.getDescription().equals(getDescription())
-                && otherFood.getCategory().equals(getCategory())
-                && otherFood.getLocation().equals(getLocation())
-                && otherFood.getOpeningHours().equals(getOpeningHours())
-                && otherFood.getRestrictions().equals(getRestrictions());
+                && otherFood.getName().equals(getName());
     }
 
     /**
@@ -146,14 +140,7 @@ public class Food {
         }
 
         Food otherFood = (Food) other;
-        return otherFood.getName().equals(getName())
-                && otherFood.getPrice().equals(getPrice())
-                && otherFood.getDescription().equals(getDescription())
-                && otherFood.getTags().equals(getTags())
-                && otherFood.getCategory().equals(getCategory())
-                && otherFood.getLocation().equals(getLocation())
-                && otherFood.getOpeningHours().equals(getOpeningHours())
-                && otherFood.getRestrictions().equals(getRestrictions());
+        return otherFood.getName().equals(getName());
     }
 
     @Override

--- a/src/main/java/seedu/savenus/model/food/Name.java
+++ b/src/main/java/seedu/savenus/model/food/Name.java
@@ -55,7 +55,7 @@ public class Name implements Field {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof Name // instanceof handles nulls
-            && fullName.equals(((Name) other).fullName)); // state check
+            && fullName.toLowerCase().equals(((Name) other).fullName.toLowerCase())); // state check
     }
 
     @Override

--- a/src/test/java/seedu/savenus/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/savenus/logic/commands/AddCommandTest.java
@@ -89,9 +89,6 @@ public class AddCommandTest {
 
         // null -> returns false
         assertFalse(addChickenRiceCommand.equals(null));
-
-        // different food -> returns false
-        assertFalse(addChickenRiceCommand.equals(addNasiLemakCommand));
     }
 
     /**

--- a/src/test/java/seedu/savenus/model/food/FoodTest.java
+++ b/src/test/java/seedu/savenus/model/food/FoodTest.java
@@ -38,19 +38,19 @@ public class FoodTest {
         // null -> returns false
         assertFalse(CARBONARA.isSameFood(null));
 
-        // different price and description -> returns true cause of name
+        // different price and description -> returns false
         Food editedAlice = new FoodBuilder(CARBONARA).withPrice(VALID_PRICE_NASI_LEMAK)
                 .withDescription(VALID_DESCRIPTION_NASI_LEMAK).build();
-        assertTrue(CARBONARA.isSameFood(editedAlice));
+        assertFalse(CARBONARA.isSameFood(editedAlice));
 
         // different name -> returns false
         editedAlice = new FoodBuilder(CARBONARA).withName(VALID_NAME_NASI_LEMAK).build();
         assertFalse(CARBONARA.isSameFood(editedAlice));
 
-        // same name, same price, different description -> returns true
+        // same name, same price, different description -> returns false
         editedAlice = new FoodBuilder(CARBONARA).withDescription(VALID_DESCRIPTION_NASI_LEMAK)
                 .build();
-        assertTrue(CARBONARA.isSameFood(editedAlice));
+        assertFalse(CARBONARA.isSameFood(editedAlice));
     }
 
     @Test
@@ -92,16 +92,16 @@ public class FoodTest {
         editedAlice = new FoodBuilder(CARBONARA).withPrice(VALID_PRICE_NASI_LEMAK).build();
         assertTrue(CARBONARA.equals(editedAlice));
 
-        // different description -> returns true
+        // different description -> returns false
         editedAlice = new FoodBuilder(CARBONARA).withDescription(VALID_DESCRIPTION_NASI_LEMAK).build();
-        assertTrue(CARBONARA.equals(editedAlice));
+        assertFalse(CARBONARA.equals(editedAlice));
 
         // different tags -> returns true
         editedAlice = new FoodBuilder(CARBONARA).withTags(VALID_TAG_CHICKEN).build();
         assertTrue(CARBONARA.equals(editedAlice));
 
-        // different location -> returns true
+        // different location -> returns false
         editedAlice = new FoodBuilder(CARBONARA).withLocation(VALID_LOCATION_NASI_LEMAK).build();
-        assertTrue(CARBONARA.equals(editedAlice));
+        assertFalse(CARBONARA.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/savenus/model/food/FoodTest.java
+++ b/src/test/java/seedu/savenus/model/food/FoodTest.java
@@ -38,27 +38,18 @@ public class FoodTest {
         // null -> returns false
         assertFalse(CARBONARA.isSameFood(null));
 
-        // different price and description -> returns false
+        // different price and description -> returns true cause of name
         Food editedAlice = new FoodBuilder(CARBONARA).withPrice(VALID_PRICE_NASI_LEMAK)
                 .withDescription(VALID_DESCRIPTION_NASI_LEMAK).build();
-        assertFalse(CARBONARA.isSameFood(editedAlice));
+        assertTrue(CARBONARA.isSameFood(editedAlice));
 
         // different name -> returns false
         editedAlice = new FoodBuilder(CARBONARA).withName(VALID_NAME_NASI_LEMAK).build();
         assertFalse(CARBONARA.isSameFood(editedAlice));
 
-        // same name, same price, different description -> returns false
+        // same name, same price, different description -> returns true
         editedAlice = new FoodBuilder(CARBONARA).withDescription(VALID_DESCRIPTION_NASI_LEMAK)
                 .build();
-        assertFalse(CARBONARA.isSameFood(editedAlice));
-
-        // same name, same description, different price -> returns false
-        editedAlice = new FoodBuilder(CARBONARA).withPrice(VALID_PRICE_NASI_LEMAK)
-                .build();
-        assertFalse(CARBONARA.isSameFood(editedAlice));
-
-        // same name, same price, same description, different tags -> returns true
-        editedAlice = new FoodBuilder(CARBONARA).withTags(VALID_TAG_CHICKEN).build();
         assertTrue(CARBONARA.isSameFood(editedAlice));
     }
 
@@ -93,24 +84,24 @@ public class FoodTest {
         // different food -> returns false
         assertFalse(CARBONARA.equals(NASI_LEMAK));
 
-        // different name -> returns false
+        // different name but same category -> returns false
         Food editedAlice = new FoodBuilder(CARBONARA).withName(VALID_NAME_NASI_LEMAK).build();
         assertFalse(CARBONARA.equals(editedAlice));
 
-        // different price -> returns false
+        // different price -> returns true
         editedAlice = new FoodBuilder(CARBONARA).withPrice(VALID_PRICE_NASI_LEMAK).build();
-        assertFalse(CARBONARA.equals(editedAlice));
+        assertTrue(CARBONARA.equals(editedAlice));
 
-        // different description -> returns false
+        // different description -> returns true
         editedAlice = new FoodBuilder(CARBONARA).withDescription(VALID_DESCRIPTION_NASI_LEMAK).build();
-        assertFalse(CARBONARA.equals(editedAlice));
+        assertTrue(CARBONARA.equals(editedAlice));
 
-        // different tags -> returns false
+        // different tags -> returns true
         editedAlice = new FoodBuilder(CARBONARA).withTags(VALID_TAG_CHICKEN).build();
-        assertFalse(CARBONARA.equals(editedAlice));
+        assertTrue(CARBONARA.equals(editedAlice));
 
-        // different location -> returns false
+        // different location -> returns true
         editedAlice = new FoodBuilder(CARBONARA).withLocation(VALID_LOCATION_NASI_LEMAK).build();
-        assertFalse(CARBONARA.equals(editedAlice));
+        assertTrue(CARBONARA.equals(editedAlice));
     }
 }


### PR DESCRIPTION
Changes the `equals` and `isSameFood` method to depend on the Food's name only. 

This is to prevent an incident where the user does 

either: 
`add n/Chicken Rice p/3.00 c/Chinese` 
`add n/chIcKen Rice p/3.00 c/Chinese` 

OR 

`add n/Chicken Rice p/3.00 c/Chinese` 
`add n/Fried Rice p/3.00 c/Chinese` 
`edit 2 n/Chicken Rice`

This PR Fixes #270 